### PR TITLE
docs: add docs directory for canonical package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Command-line interface for the Bunary framework. Provides project scaffolding and development tools.
 
+## Documentation
+
+Canonical documentation for this package lives in [`docs/index.md`](./docs/index.md).
+
 ## Installation
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+# @bunary/cli
+
+Command-line interface for the Bunary framework. Provides project scaffolding and developer tooling.
+
+## Installation
+
+```bash
+bun add -g @bunary/cli
+```
+
+Or use directly with `bunx`:
+
+```bash
+bunx @bunary/cli --help
+```
+
+## Commands (high level)
+
+- `bunary init [name]` — Create a new Bunary project
+- `bunary model:make <table-name>` — Generate an ORM model file
+
+See the README for the full command reference until the CLI docs are expanded.
+
+## Requirements
+
+- Bun ≥ 1.0.0
+


### PR DESCRIPTION
## Summary
- Add `docs/index.md` as the canonical documentation entry for `@bunary/cli`.
- Update the README to point to the `docs/` directory.

## Test plan
- N/A (documentation only)

Closes #20