### PR TITLE
feat(cli): bunary init scaffolds src/routes/ (Closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.6] - 2026-01-29
 
-### Changed
+### Added
 
-- Moved stubs from `src/stubs/` to top-level `stubs/` directory (Closes #25)
-  - Template files are no longer inside `src/`, simplifying tsconfig and biome
-  - Build copies from `stubs/` to `dist/stubs/`; dev uses `stubs/` at package root
-  - Removed `src/stubs` from tsconfig exclude and biome ignore; stubs now ignored via `stubs/**`
+- **`bunary init` scaffolds `src/routes/`** (Closes #14)
+  - Creates `src/routes/main.ts` (registers `/` and `/health`)
+  - Creates `src/routes/groupExample.ts` (example `/api` group with `/api/health`)
+  - Creates `src/routes/index.ts` (aggregates route registration)
+  - `src/index.ts` now imports and calls `registerRoutes(app)` instead of defining routes inline
 
 ## [0.0.5] - 2026-01-26
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ bunary init .
 This creates a new Bunary project with:
 - `package.json` - Pre-configured with Bunary dependencies
 - `bunary.config.ts` - Application configuration
-- `src/index.ts` - Entry point with a working server
+- `src/index.ts` - Entry point that registers routes via `src/routes/`
+- `src/routes/` - Route modules: `main.ts`, `groupExample.ts`, `index.ts`
 
 **Generated Project Structure:**
 ```
@@ -43,7 +44,11 @@ my-app/
 ├── package.json
 ├── bunary.config.ts
 └── src/
-    └── index.ts
+    ├── index.ts
+    └── routes/
+        ├── index.ts   # Aggregates route registration
+        ├── main.ts    # Base routes (/ and /health)
+        └── groupExample.ts  # Example /api group
 ```
 
 **Next Steps:**
@@ -127,24 +132,24 @@ export default defineConfig({
 
 ### src/index.ts
 
+The entrypoint creates the app and registers routes from `src/routes/`:
+
 ```typescript
 import { createApp } from "@bunary/http";
+import { registerRoutes } from "./routes/index.js";
 
 const app = createApp();
-
-app.get("/", () => ({
-  message: "Welcome to Bunary!",
-  docs: "https://github.com/bunary-dev",
-}));
-
-app.get("/health", () => ({
-  status: "ok",
-  timestamp: new Date().toISOString(),
-}));
+registerRoutes(app);
 
 const server = app.listen(3000);
 console.log(`🚀 Server running at http://localhost:${server.port}`);
 ```
+
+### src/routes/
+
+- **index.ts** — Calls all route registration functions.
+- **main.ts** — Registers base routes: `/` and `/health`.
+- **groupExample.ts** — Example route group: `/api` with `/api/health`.
 
 ## Programmatic API
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "CLI scaffolding tool for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,11 @@ import { basename, join, resolve } from "node:path";
 import { generateConfig } from "./project/config.js";
 import { generateEntrypoint } from "./project/entrypoint.js";
 import { generatePackageJson } from "./project/packageJson.js";
+import {
+	generateRoutesGroupExample,
+	generateRoutesIndex,
+	generateRoutesMain,
+} from "./project/routes.js";
 
 /**
  * Initialize a new Bunary project.
@@ -24,8 +29,9 @@ export async function init(name: string): Promise<void> {
 		await mkdir(projectDir, { recursive: true });
 	}
 
-	// Create src directory
+	// Create src and src/routes directories
 	await mkdir(join(projectDir, "src"), { recursive: true });
+	await mkdir(join(projectDir, "src", "routes"), { recursive: true });
 
 	// Write files
 	await writeFile(
@@ -40,6 +46,18 @@ export async function init(name: string): Promise<void> {
 		join(projectDir, "src", "index.ts"),
 		await generateEntrypoint(),
 	);
+	await writeFile(
+		join(projectDir, "src", "routes", "main.ts"),
+		await generateRoutesMain(),
+	);
+	await writeFile(
+		join(projectDir, "src", "routes", "groupExample.ts"),
+		await generateRoutesGroupExample(),
+	);
+	await writeFile(
+		join(projectDir, "src", "routes", "index.ts"),
+		await generateRoutesIndex(),
+	);
 
 	console.log(`\n✨ Created Bunary project: ${projectName}\n`);
 	console.log("Next steps:");
@@ -52,4 +70,9 @@ export async function init(name: string): Promise<void> {
 
 // Re-export generators and commands for programmatic use
 export { generateConfig, generateEntrypoint, generatePackageJson };
+export {
+	generateRoutesGroupExample,
+	generateRoutesIndex,
+	generateRoutesMain,
+} from "./project/routes.js";
 export { makeModel } from "./model/makeModel.js";

--- a/src/commands/project/routes.ts
+++ b/src/commands/project/routes.ts
@@ -1,0 +1,16 @@
+/**
+ * Generate src/routes/ file contents.
+ */
+import { loadStub } from "../../utils/stub.js";
+
+export async function generateRoutesMain(): Promise<string> {
+	return await loadStub("project/routes/main.ts", {});
+}
+
+export async function generateRoutesGroupExample(): Promise<string> {
+	return await loadStub("project/routes/groupExample.ts", {});
+}
+
+export async function generateRoutesIndex(): Promise<string> {
+	return await loadStub("project/routes/index.ts", {});
+}

--- a/stubs/project/entrypoint.ts
+++ b/stubs/project/entrypoint.ts
@@ -1,16 +1,8 @@
 import { createApp } from "@bunary/http";
+import { registerRoutes } from "./routes/index.js";
 
 const app = createApp();
-
-app.get("/", () => ({
-  message: "Welcome to Bunary!",
-  docs: "https://github.com/bunary-dev",
-}));
-
-app.get("/health", () => ({
-  status: "ok",
-  timestamp: new Date().toISOString(),
-}));
+registerRoutes(app);
 
 const server = app.listen(3000);
 console.log(`🚀 Server running at http://localhost:${server.port}`);

--- a/stubs/project/routes/groupExample.ts
+++ b/stubs/project/routes/groupExample.ts
@@ -1,0 +1,15 @@
+import type { BunaryApp } from "@bunary/http";
+
+/**
+ * Example route group: /api prefix.
+ * Routes here are mounted at /api/...
+ */
+export function registerGroupExample(app: BunaryApp): void {
+	app.group("/api", (router) => {
+		router.get("/health", () => ({
+			status: "ok",
+			api: true,
+			timestamp: new Date().toISOString(),
+		}));
+	});
+}

--- a/stubs/project/routes/index.ts
+++ b/stubs/project/routes/index.ts
@@ -1,0 +1,12 @@
+import type { BunaryApp } from "@bunary/http";
+import { registerMain } from "./main.js";
+import { registerGroupExample } from "./groupExample.js";
+
+/**
+ * Register all application routes.
+ * Add new route modules here and call their register function.
+ */
+export function registerRoutes(app: BunaryApp): void {
+	registerMain(app);
+	registerGroupExample(app);
+}

--- a/stubs/project/routes/main.ts
+++ b/stubs/project/routes/main.ts
@@ -1,0 +1,16 @@
+import type { BunaryApp } from "@bunary/http";
+
+/**
+ * Register base routes: / and /health
+ */
+export function registerMain(app: BunaryApp): void {
+	app.get("/", () => ({
+		message: "Welcome to Bunary!",
+		docs: "https://github.com/bunary-dev",
+	}));
+
+	app.get("/health", () => ({
+		status: "ok",
+		timestamp: new Date().toISOString(),
+	}));
+}

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -58,6 +58,34 @@ describe("init command", () => {
 			expect(existsSync(join(projectDir, "src", "index.ts"))).toBe(true);
 		});
 
+		test("creates src/routes/ with index.ts, main.ts, groupExample.ts", async () => {
+			const projectDir = join(TEST_DIR, "my-app");
+			process.chdir(TEST_DIR);
+			await init("my-app");
+
+			expect(existsSync(join(projectDir, "src", "routes", "index.ts"))).toBe(
+				true,
+			);
+			expect(existsSync(join(projectDir, "src", "routes", "main.ts"))).toBe(
+				true,
+			);
+			expect(
+				existsSync(join(projectDir, "src", "routes", "groupExample.ts")),
+			).toBe(true);
+		});
+
+		test("src/index.ts uses registerRoutes from routes module", async () => {
+			const projectDir = join(TEST_DIR, "my-app");
+			process.chdir(TEST_DIR);
+			await init("my-app");
+
+			const entrypointPath = join(projectDir, "src", "index.ts");
+			const content = await Bun.file(entrypointPath).text();
+			expect(content).toContain("registerRoutes");
+			expect(content).toContain("routes/index");
+			expect(content).not.toContain('app.get("/",');
+		});
+
 		test("works with '.' for current directory", async () => {
 			const projectDir = join(TEST_DIR, "current-dir-test");
 			await mkdir(projectDir, { recursive: true });
@@ -67,6 +95,9 @@ describe("init command", () => {
 			expect(existsSync(join(projectDir, "package.json"))).toBe(true);
 			expect(existsSync(join(projectDir, "bunary.config.ts"))).toBe(true);
 			expect(existsSync(join(projectDir, "src", "index.ts"))).toBe(true);
+			expect(existsSync(join(projectDir, "src", "routes", "index.ts"))).toBe(
+				true,
+			);
 		});
 	});
 
@@ -126,9 +157,10 @@ describe("init command", () => {
 			expect(entry).toContain("createApp");
 		});
 
-		test("includes a GET route", async () => {
+		test("includes registerRoutes from routes module", async () => {
 			const entry = await generateEntrypoint();
-			expect(entry).toContain(".get(");
+			expect(entry).toContain("registerRoutes");
+			expect(entry).toContain("routes/index");
 		});
 
 		test("includes app.listen()", async () => {


### PR DESCRIPTION
## Summary

Implements CLI issue #14: `bunary init` now scaffolds a `src/routes/` directory structure by default.

## Changes

- **src/routes/main.ts** — Registers base routes (`/` and `/health`)
- **src/routes/groupExample.ts** — Example route group (`/api` with `/api/health`)
- **src/routes/index.ts** — Aggregates route registration (calls `registerMain`, `registerGroupExample`)
- **src/index.ts** — Updated to import and call `registerRoutes(app)` instead of defining routes inline

## Acceptance criteria

- [x] `bunary init` creates the 3 new files under `src/routes/`
- [x] `src/index.ts` no longer contains inline route definitions; uses routes module
- [x] Tests updated/added to assert generated file tree and key content
- [x] README updated with new project structure and entrypoint example

## Testing

- All 42 tests pass
- Lint passes
- Build succeeds

Closes #14