### PR TITLE
feat(cli): add route:make generator (Closes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7] - 2026-01-29
+
+### Added
+
+- **`bunary route:make <name>`** (Closes #15)
+  - Generates a route module in `src/routes/<name>.ts` with a register function
+  - Stub uses placeholders `{{routeName}}` and `{{functionName}}` (e.g. users → registerUsers)
+  - Command documented in CLI help and README
+  - Requires Bunary project (package.json with @bunary/core)
+
 ## [0.0.6] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,32 @@ src/models/
 └── Users.ts  # Generated from "users" table name
 ```
 
+### `bunary route:make <name>`
+
+Generate a route module in `src/routes/`.
+
+```bash
+# Generate a route module
+bunary route:make users       # Creates src/routes/users.ts with registerUsers(app)
+bunary route:make user-profile  # Creates src/routes/user-profile.ts with registerUserProfile(app)
+
+# The command automatically:
+# - Creates the file in src/routes/ directory
+# - Generates a register function (e.g. registerUsers) for the route name
+# - Validates you're in a Bunary project
+# - Prevents overwriting existing files
+```
+
+**Requirements:**
+- Must be run from within a Bunary project directory
+- Project must have `@bunary/core` in `package.json` dependencies
+
+**Generated Route Structure:**
+```
+src/routes/
+└── users.ts  # Exports registerUsers(app); add it to src/routes/index.ts manually
+```
+
 ### Options
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "CLI scaffolding tool for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/route/makeRoute.ts
+++ b/src/commands/route/makeRoute.ts
@@ -1,0 +1,56 @@
+/**
+ * route:make command - scaffold route module files
+ */
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { routeNameToRegisterFunctionName } from "../../utils/naming.js";
+import { loadStub } from "../../utils/stub.js";
+import { isBunaryProject } from "../../utils/validation.js";
+
+/**
+ * Generate a route module file in src/routes/.
+ *
+ * Validates that the current directory is a Bunary project,
+ * then creates a route file in src/routes/ directory.
+ *
+ * @param routeName - Route name (e.g. "users", "user-profile")
+ * @throws Error if not in a Bunary project or file already exists
+ *
+ * @example
+ * ```ts
+ * await makeRoute("users");
+ * // Creates src/routes/users.ts with registerUsers(app)
+ * ```
+ */
+export async function makeRoute(routeName: string): Promise<void> {
+	const cwd = process.cwd();
+
+	if (!isBunaryProject(cwd)) {
+		throw new Error(
+			"Error: Not in a Bunary project.\n" +
+				"Make sure you're in a directory with package.json containing @bunary/core dependency.",
+		);
+	}
+
+	const functionName = routeNameToRegisterFunctionName(routeName);
+	const routesDir = join(cwd, "src", "routes");
+	const routePath = join(routesDir, `${routeName}.ts`);
+
+	if (existsSync(routePath)) {
+		throw new Error(
+			`Error: Route file ${routePath} already exists.\nDelete the existing file if you want to regenerate it.`,
+		);
+	}
+
+	await mkdir(routesDir, { recursive: true });
+
+	const content = await loadStub("route/make.ts", {
+		routeName,
+		functionName,
+	});
+
+	await writeFile(routePath, content, "utf-8");
+
+	console.log(`✅ Created route: ${routePath}`);
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -29,6 +29,11 @@ const commands: Command[] = [
 		description: "Generate an ORM model class for the given table name",
 		usage: "bunary model:make <table-name>",
 	},
+	{
+		name: "route:make <name>",
+		description: "Generate a route module in src/routes/",
+		usage: "bunary route:make <name>",
+	},
 ];
 
 const options: Option[] = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,17 @@
  *   bunary init <name>        - Create a new project in <name> directory
  *   bunary init .             - Create a new project in current directory
  *   bunary model:make <table> - Generate an ORM model for <table>
+ *   bunary route:make <name>  - Generate a route module in src/routes/
  *   bunary --help             - Show help
  *   bunary --version          - Show version
  */
 
 import { init } from "./commands/init.js";
 import { makeModel } from "./commands/model/makeModel.js";
+import { makeRoute } from "./commands/route/makeRoute.js";
 import { showHelp } from "./help.js";
 
-const VERSION = "0.0.5";
+const VERSION = "0.0.7";
 const args = process.argv.slice(2);
 
 async function main(): Promise<void> {
@@ -50,6 +52,22 @@ async function main(): Promise<void> {
 		}
 		try {
 			await makeModel(tableName);
+		} catch (error) {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exit(1);
+		}
+		return;
+	}
+
+	if (args[0] === "route:make") {
+		const routeName = args[1];
+		if (!routeName) {
+			console.error("Error: Route name is required");
+			console.error("Usage: bunary route:make <name>");
+			process.exit(1);
+		}
+		try {
+			await makeRoute(routeName);
 		} catch (error) {
 			console.error(error instanceof Error ? error.message : String(error));
 			process.exit(1);

--- a/src/utils/naming.ts
+++ b/src/utils/naming.ts
@@ -37,3 +37,24 @@ export function tableNameToModelName(tableName: string): string {
 
 	return words.join("");
 }
+
+/**
+ * Convert a route name to the register function name (camelCase).
+ * Used for route module stubs: "users" → "registerUsers".
+ *
+ * @param routeName - The route name (e.g. "users", "user-profile")
+ * @returns The register function name (e.g. "registerUsers", "registerUserProfile")
+ *
+ * @example
+ * ```ts
+ * routeNameToRegisterFunctionName("users") // "registerUsers"
+ * routeNameToRegisterFunctionName("user-profile") // "registerUserProfile"
+ * ```
+ */
+export function routeNameToRegisterFunctionName(routeName: string): string {
+	if (!routeName || routeName.length === 0) {
+		throw new Error("Route name cannot be empty");
+	}
+	const pascal = tableNameToModelName(routeName);
+	return `register${pascal}`;
+}

--- a/stubs/route/make.ts
+++ b/stubs/route/make.ts
@@ -1,0 +1,9 @@
+import type { BunaryApp } from "@bunary/http";
+
+/**
+ * Register {{routeName}} routes.
+ */
+export function {{functionName}}(app: BunaryApp): void {
+	// Add routes here, e.g.:
+	// app.get("/{{routeName}}", () => ({ list: [] }));
+}

--- a/tests/commands/make-route.test.ts
+++ b/tests/commands/make-route.test.ts
@@ -1,0 +1,94 @@
+/**
+ * route:make command tests
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { makeRoute } from "../../src/commands/route/makeRoute.js";
+
+describe("route:make command", () => {
+	let testDir: string;
+	let originalCwd: string;
+
+	beforeEach(async () => {
+		originalCwd = process.cwd();
+		testDir = await mkdtemp(join(tmpdir(), "bunary-cli-make-route-test-"));
+		process.chdir(testDir);
+
+		const packageJson = {
+			name: "test-project",
+			dependencies: {
+				"@bunary/core": "^0.0.5",
+			},
+		};
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify(packageJson, null, 2),
+		);
+		await mkdir(join(testDir, "src", "routes"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		try {
+			if (originalCwd && existsSync(originalCwd)) {
+				process.chdir(originalCwd);
+			}
+		} catch {
+			// ignore
+		}
+		if (testDir) {
+			try {
+				await rm(testDir, { recursive: true, force: true });
+			} catch {
+				// ignore
+			}
+		}
+	});
+
+	it("should create route file in src/routes directory", async () => {
+		await makeRoute("users");
+
+		const routePath = join(testDir, "src", "routes", "users.ts");
+		expect(existsSync(routePath)).toBe(true);
+	});
+
+	it("should generate with correct function name", async () => {
+		await makeRoute("users");
+
+		const routePath = join(testDir, "src", "routes", "users.ts");
+		const content = readFileSync(routePath, "utf-8");
+		expect(content).toContain("export function registerUsers");
+		expect(content).toContain("BunaryApp");
+	});
+
+	it("should convert kebab-case route name to register function name", async () => {
+		await makeRoute("user-profile");
+
+		const routePath = join(testDir, "src", "routes", "user-profile.ts");
+		expect(existsSync(routePath)).toBe(true);
+		const content = readFileSync(routePath, "utf-8");
+		expect(content).toContain("registerUserProfile");
+	});
+
+	it("should not overwrite existing route file", async () => {
+		await makeRoute("users");
+
+		await expect(makeRoute("users")).rejects.toThrow("already exists");
+	});
+
+	it("should throw error if not in a Bunary project", async () => {
+		await rm(join(testDir, "package.json"));
+
+		await expect(makeRoute("users")).rejects.toThrow("Not in a Bunary project");
+	});
+
+	it("should create src/routes directory if it does not exist", async () => {
+		await rm(join(testDir, "src", "routes"), { recursive: true, force: true });
+
+		await makeRoute("users");
+
+		expect(existsSync(join(testDir, "src", "routes", "users.ts"))).toBe(true);
+	});
+});

--- a/tests/utils/naming.test.ts
+++ b/tests/utils/naming.test.ts
@@ -2,7 +2,10 @@
  * Naming utilities tests
  */
 import { describe, expect, it } from "bun:test";
-import { tableNameToModelName } from "../../src/utils/naming.js";
+import {
+	routeNameToRegisterFunctionName,
+	tableNameToModelName,
+} from "../../src/utils/naming.js";
 
 describe("tableNameToModelName", () => {
 	it("should convert snake_case to PascalCase", () => {
@@ -44,5 +47,30 @@ describe("tableNameToModelName", () => {
 
 	it("should handle single character", () => {
 		expect(tableNameToModelName("u")).toBe("U");
+	});
+});
+
+describe("routeNameToRegisterFunctionName", () => {
+	it("should convert route name to register function name", () => {
+		expect(routeNameToRegisterFunctionName("users")).toBe("registerUsers");
+		expect(routeNameToRegisterFunctionName("posts")).toBe("registerPosts");
+	});
+
+	it("should handle kebab-case route names", () => {
+		expect(routeNameToRegisterFunctionName("user-profile")).toBe(
+			"registerUserProfile",
+		);
+	});
+
+	it("should handle snake_case route names", () => {
+		expect(routeNameToRegisterFunctionName("user_profile")).toBe(
+			"registerUserProfile",
+		);
+	});
+
+	it("should throw error for empty string", () => {
+		expect(() => routeNameToRegisterFunctionName("")).toThrow(
+			"Route name cannot be empty",
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Adds `bunary route:make <name>` to scaffold route modules under `src/routes/` (Closes #15).

## Changes

- **Command:** `bunary route:make <name>` — creates `src/routes/<name>.ts`
- **Stub:** `stubs/route/make.ts` with placeholders `{{routeName}}`, `{{functionName}}` (e.g. users → registerUsers)
- **Naming:** `routeNameToRegisterFunctionName()` in `src/utils/naming.ts`
- **CLI:** Command registered in `index.ts` and `help.ts`
- **Tests:** 6 route:make tests + 4 naming tests for `routeNameToRegisterFunctionName`

## Acceptance criteria

- [x] Command exists and is documented in CLI help/README
- [x] Generates a route module file in `src/routes/`
- [ ] (Optional) Auto-wire into `src/routes/index.ts` — not implemented; user adds import and call manually
- [x] Tests cover generation and validation

## Testing

- All 52 tests pass
- Lint passes
- Build succeeds

Closes #15