### PR TITLE
feat: bunary init --umbrella (Closes #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.12] - 2026-01-29
+
+### Added
+
+- **`bunary init --umbrella`** (Closes #18)
+  - Scaffolds project with umbrella `bunary` package instead of individual `@bunary/core` and `@bunary/http`
+  - `package.json` gets dependency `bunary`; generated imports use `bunary/http` and `bunary/core`
+  - Without `--umbrella`, behavior unchanged (default remains `@bunary/*` deps)
+
 ## [0.0.11] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ bunx @bunary/cli init my-app
 
 ## Commands
 
-### `bunary init [name] [--auth basic|jwt]`
+### `bunary init [name] [--auth basic|jwt] [--umbrella]`
 
-Create a new Bunary project, optionally with Basic or JWT auth scaffolding.
+Create a new Bunary project, optionally with Basic or JWT auth scaffolding, or using the umbrella `bunary` package.
 
 ```bash
 # Create a new project in a directory
@@ -34,12 +34,15 @@ bunary init my-app --auth basic
 # Scaffold with JWT (env: JWT_SECRET)
 bunary init my-app --auth jwt
 
+# Use umbrella package (bunary instead of @bunary/core + @bunary/http)
+bunary init my-app --umbrella
+
 # Create a project in the current directory
 bunary init .
 ```
 
 This creates a new Bunary project with:
-- `package.json` - Pre-configured with Bunary dependencies (includes `@bunary/auth` when `--auth` is used)
+- `package.json` - Pre-configured with Bunary dependencies (`@bunary/core` + `@bunary/http` by default; single `bunary` when `--umbrella`; includes `@bunary/auth` when `--auth` is used)
 - `bunary.config.ts` - Application configuration
 - `src/index.ts` - Entry point that registers routes via `src/routes/` (and `app.use(authMiddleware)` when `--auth` is used)
 - `src/routes/` - Route modules: `main.ts`, `groupExample.ts`, `index.ts`

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ bunx @bunary/cli --help
 
 ## Commands (high level)
 
-- `bunary init [name] [--auth basic|jwt]` — Create a new Bunary project (optionally with Basic or JWT auth scaffolding)
+- `bunary init [name] [--auth basic|jwt] [--umbrella]` — Create a new Bunary project (optionally with Basic or JWT auth; `--umbrella` uses `bunary` package instead of `@bunary/*`)
 - `bunary model:make <table-name>` — Generate an ORM model file
 - `bunary make:middleware <name>` — Generate a middleware in src/middleware/ (Laravel-inspired)
 - `bunary make:migration <name>` — Create a migration in ./migrations/ (Laravel-inspired)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "CLI scaffolding tool for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -20,11 +20,12 @@ export type { InitOptions } from "./project/types.js";
  * Initialize a new Bunary project.
  *
  * @param name - Project name or "." for current directory
- * @param options - Optional: auth "basic" or "jwt" to scaffold auth middleware
+ * @param options - Optional: auth "basic" or "jwt" to scaffold auth middleware; umbrella true to use bunary package instead of @bunary/*
  * @example
  * ```ts
  * await init("my-api");
  * await init("my-api", { auth: "jwt" });
+ * await init("my-api", { umbrella: true });
  * ```
  */
 export async function init(name: string, options?: InitOptions): Promise<void> {
@@ -53,7 +54,7 @@ export async function init(name: string, options?: InitOptions): Promise<void> {
 	);
 	await writeFile(
 		join(projectDir, "bunary.config.ts"),
-		await generateConfig(projectName),
+		await generateConfig(projectName, options),
 	);
 	await writeFile(
 		join(projectDir, "src", "index.ts"),
@@ -68,15 +69,15 @@ export async function init(name: string, options?: InitOptions): Promise<void> {
 	}
 	await writeFile(
 		join(projectDir, "src", "routes", "main.ts"),
-		await generateRoutesMain(),
+		await generateRoutesMain(options),
 	);
 	await writeFile(
 		join(projectDir, "src", "routes", "groupExample.ts"),
-		await generateRoutesGroupExample(),
+		await generateRoutesGroupExample(options),
 	);
 	await writeFile(
 		join(projectDir, "src", "routes", "index.ts"),
-		await generateRoutesIndex(),
+		await generateRoutesIndex(options),
 	);
 
 	console.log(`\n✨ Created Bunary project: ${projectName}\n`);

--- a/src/commands/project/config.ts
+++ b/src/commands/project/config.ts
@@ -2,7 +2,15 @@
  * Generate bunary.config.ts content.
  */
 import { loadStub } from "../../utils/stub.js";
+import type { InitOptions } from "./types.js";
 
-export async function generateConfig(name: string): Promise<string> {
-	return await loadStub("project/config.ts", { name });
+const BUNARY_CORE = "@bunary/core";
+const BUNARY_CORE_UMBRELLA = "bunary/core";
+
+export async function generateConfig(
+	name: string,
+	options?: InitOptions,
+): Promise<string> {
+	const bunaryCore = options?.umbrella ? BUNARY_CORE_UMBRELLA : BUNARY_CORE;
+	return await loadStub("project/config.ts", { name, bunaryCore });
 }

--- a/src/commands/project/entrypoint.ts
+++ b/src/commands/project/entrypoint.ts
@@ -12,6 +12,9 @@ import type { InitOptions } from "./types.js";
  * @param options - When auth is "basic" or "jwt", adds import and app.use(basicMiddleware|jwtMiddleware)
  * @returns Entrypoint TypeScript content
  */
+const BUNARY_HTTP = "@bunary/http";
+const BUNARY_HTTP_UMBRELLA = "bunary/http";
+
 export async function generateEntrypoint(
 	options?: InitOptions,
 ): Promise<string> {
@@ -22,8 +25,10 @@ export async function generateEntrypoint(
 		authImport = `import { ${exportName} } from "./middleware/${options.auth}.js";\n\n`;
 		authUse = `app.use(${exportName});\n`;
 	}
+	const bunaryHttp = options?.umbrella ? BUNARY_HTTP_UMBRELLA : BUNARY_HTTP;
 	return await loadStub("project/entrypoint.ts", {
 		authImport,
 		authUse,
+		bunaryHttp,
 	});
 }

--- a/src/commands/project/packageJson.ts
+++ b/src/commands/project/packageJson.ts
@@ -7,11 +7,14 @@ import type { InitOptions } from "./types.js";
 /** @bunary/auth version for init --auth. Update when publishing a new auth release. */
 const BUNARY_AUTH_VERSION = "^0.0.7";
 
+/** Umbrella package version for init --umbrella. Sync with umbrella package release. */
+const BUNARY_UMBRELLA_VERSION = "^0.0.1";
+
 /**
  * Generate package.json content.
  *
  * @param name - Project name
- * @param options - Optional init options (e.g. auth) to add @bunary/auth dependency
+ * @param options - Optional init options (auth, umbrella) to set dependencies
  * @returns JSON string
  */
 export async function generatePackageJson(
@@ -22,6 +25,9 @@ export async function generatePackageJson(
 	const parsed = JSON.parse(content) as Record<string, unknown> & {
 		dependencies?: Record<string, string>;
 	};
+	if (options?.umbrella) {
+		parsed.dependencies = { bunary: BUNARY_UMBRELLA_VERSION };
+	}
 	if (options?.auth === "basic" || options?.auth === "jwt") {
 		parsed.dependencies = parsed.dependencies ?? {};
 		parsed.dependencies["@bunary/auth"] = BUNARY_AUTH_VERSION;

--- a/src/commands/project/routes.ts
+++ b/src/commands/project/routes.ts
@@ -2,15 +2,36 @@
  * Generate src/routes/ file contents.
  */
 import { loadStub } from "../../utils/stub.js";
+import type { InitOptions } from "./types.js";
 
-export async function generateRoutesMain(): Promise<string> {
-	return await loadStub("project/routes/main.ts", {});
+function bunaryHttpReplacement(options?: InitOptions): Record<string, string> {
+	const bunaryHttp = options?.umbrella ? "bunary/http" : "@bunary/http";
+	return { bunaryHttp };
 }
 
-export async function generateRoutesGroupExample(): Promise<string> {
-	return await loadStub("project/routes/groupExample.ts", {});
+export async function generateRoutesMain(
+	options?: InitOptions,
+): Promise<string> {
+	return await loadStub(
+		"project/routes/main.ts",
+		bunaryHttpReplacement(options),
+	);
 }
 
-export async function generateRoutesIndex(): Promise<string> {
-	return await loadStub("project/routes/index.ts", {});
+export async function generateRoutesGroupExample(
+	options?: InitOptions,
+): Promise<string> {
+	return await loadStub(
+		"project/routes/groupExample.ts",
+		bunaryHttpReplacement(options),
+	);
+}
+
+export async function generateRoutesIndex(
+	options?: InitOptions,
+): Promise<string> {
+	return await loadStub(
+		"project/routes/index.ts",
+		bunaryHttpReplacement(options),
+	);
 }

--- a/src/commands/project/types.ts
+++ b/src/commands/project/types.ts
@@ -2,7 +2,9 @@
  * Shared types for init command and project generators.
  */
 
-/** Options for `bunary init` (e.g. auth scaffolding). */
+/** Options for `bunary init` (e.g. auth scaffolding, umbrella package). */
 export interface InitOptions {
 	auth?: "basic" | "jwt";
+	/** Use umbrella `bunary` package instead of individual @bunary/* deps. */
+	umbrella?: boolean;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -19,10 +19,10 @@ interface Option {
 
 const commands: Command[] = [
 	{
-		name: "init <name|.> [--auth basic|jwt]",
+		name: "init <name|.> [--auth basic|jwt] [--umbrella]",
 		description:
-			"Create a new Bunary project (optionally with Basic or JWT auth scaffolding)",
-		usage: "bunary init <name|.> [--auth basic|jwt]",
+			"Create a new Bunary project (optionally with Basic or JWT auth; --umbrella uses bunary package instead of @bunary/*)",
+		usage: "bunary init <name|.> [--auth basic|jwt] [--umbrella]",
 	},
 	{
 		name: "model:make <table-name>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import { makeModel } from "./commands/model/makeModel.js";
 import { makeRoute } from "./commands/route/makeRoute.js";
 import { showHelp } from "./help.js";
 
-const VERSION = "0.0.11";
+const VERSION = "0.0.12";
 const args = process.argv.slice(2);
 
 async function main(): Promise<void> {
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
 		if (!name) {
 			console.error("Error: Project name is required");
 			console.error(
-				"Usage: bunary init <name> [--auth basic|jwt]  (or 'bunary init .' for current directory)",
+				"Usage: bunary init <name> [--auth basic|jwt] [--umbrella]  (or 'bunary init .' for current directory)",
 			);
 			process.exit(1);
 		}
@@ -60,7 +60,8 @@ async function main(): Promise<void> {
 				auth = value;
 			}
 		}
-		await init(name, { auth });
+		const umbrella = args.includes("--umbrella");
+		await init(name, { auth, umbrella });
 		return;
 	}
 

--- a/stubs/project/config.ts
+++ b/stubs/project/config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@bunary/core";
+import { defineConfig } from "{{bunaryCore}}";
 
 export default defineConfig({
   app: {

--- a/stubs/project/entrypoint.ts
+++ b/stubs/project/entrypoint.ts
@@ -1,4 +1,4 @@
-import { createApp } from "@bunary/http";
+import { createApp } from "{{bunaryHttp}}";
 import { registerRoutes } from "./routes/index.js";
 {{authImport}}
 // If supported by your @bunary/http version, you can pass { basePath: "/api" } to prefix all routes:

--- a/stubs/project/routes/groupExample.ts
+++ b/stubs/project/routes/groupExample.ts
@@ -1,4 +1,4 @@
-import type { BunaryApp } from "@bunary/http";
+import type { BunaryApp } from "{{bunaryHttp}}";
 
 /**
  * Example route group: /api prefix.

--- a/stubs/project/routes/index.ts
+++ b/stubs/project/routes/index.ts
@@ -1,4 +1,4 @@
-import type { BunaryApp } from "@bunary/http";
+import type { BunaryApp } from "{{bunaryHttp}}";
 import { registerMain } from "./main.js";
 import { registerGroupExample } from "./groupExample.js";
 

--- a/stubs/project/routes/main.ts
+++ b/stubs/project/routes/main.ts
@@ -1,4 +1,4 @@
-import type { BunaryApp } from "@bunary/http";
+import type { BunaryApp } from "{{bunaryHttp}}";
 
 /**
  * Register base routes: / and /health


### PR DESCRIPTION
## Summary
Implements `bunary init --umbrella` to scaffold projects using the umbrella `bunary` package instead of individual `@bunary/core` and `@bunary/http`.

### Added
- **`bunary init <name> [--umbrella]`** — With `--umbrella`, `package.json` gets dependency `bunary`; generated imports use `bunary/http` and `bunary/core`
- Without the flag, behavior is unchanged (default remains `@bunary/*` deps)

### Implementation
- `InitOptions.umbrella`; stubs use `{{bunaryHttp}}` / `{{bunaryCore}}` placeholders; `generatePackageJson`, `generateConfig`, `generateEntrypoint`, route generators pass replacements
- Tests cover both variants; help, README, docs, CHANGELOG updated; v0.0.12

Closes #18