### PR TITLE
patch: rename make:migration and make:middleware to migration:make and middleware:make (Closes #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Migration commands** (Closes #13)
-  - `bunary make:migration <name>` — Create a migration in `./migrations/` with timestamp prefix (Laravel-style)
+  - `bunary migration:make <name>` — Create a migration in `./migrations/` with timestamp prefix (Laravel-style)
   - `bunary migrate` — Run pending migrations (up)
   - `bunary migrate:rollback` — Rollback last batch (down)
   - `bunary migrate:status` — Show ran / pending migrations
@@ -30,13 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`bunary make:middleware <name>`** (Laravel-inspired)
+- **`bunary middleware:make <name>`** (Laravel-inspired)
   - Generates a middleware file in `src/middleware/<name>.ts` with a camelCase export (e.g. ensure-auth → ensureAuthMiddleware)
   - Requires Bunary project; documented in help and README
 
 ### Changed
 
-- **Auth scaffolding** uses the same code path as `make:middleware`: auth stubs moved to `stubs/middleware/auth-basic.ts` and `auth-jwt.ts`; `init --auth basic|jwt` creates `src/middleware/basic.ts` or `jwt.ts` (same content as `bunary make:middleware basic|jwt`). Entrypoint imports `basicMiddleware`/`jwtMiddleware` from `./middleware/basic.js` or `./middleware/jwt.js`. Removed duplicate `project/auth.ts` and `stubs/project/auth-*.ts`.
+- **Auth scaffolding** uses the same code path as `middleware:make`: auth stubs moved to `stubs/middleware/auth-basic.ts` and `auth-jwt.ts`; `init --auth basic|jwt` creates `src/middleware/basic.ts` or `jwt.ts` (same content as `bunary middleware:make basic|jwt`). Entrypoint imports `basicMiddleware`/`jwtMiddleware` from `./middleware/basic.js` or `./middleware/jwt.js`. Removed duplicate `project/auth.ts` and `stubs/project/auth-*.ts`.
 
 ## [0.0.9] - 2026-01-29
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ bunx @bunary/cli init my-app
 |--------|-------------|
 | `bunary init [name] [--auth basic\|jwt] [--umbrella]` | Create a new Bunary project |
 | `bunary model:make <table>` | Generate ORM model in `src/models/` |
-| `bunary make:middleware <name>` | Generate middleware in `src/middleware/` |
-| `bunary make:migration <name>` | Create migration in `./migrations/` |
+| `bunary middleware:make <name>` | Generate middleware in `src/middleware/` |
+| `bunary migration:make <name>` | Create migration in `./migrations/` |
 | `bunary migrate` | Run pending migrations |
 | `bunary migrate:rollback` | Rollback last migration batch |
 | `bunary migrate:status` | Show migration status |
@@ -58,7 +58,7 @@ This creates a new Bunary project with:
 - `bunary.config.ts` - Application configuration
 - `src/index.ts` - Entry point that registers routes via `src/routes/` (and `app.use(authMiddleware)` when `--auth` is used)
 - `src/routes/` - Route modules: `main.ts`, `groupExample.ts`, `index.ts`
-- `src/middleware/basic.ts` or `src/middleware/jwt.ts` - Auth middleware (only when `--auth basic` or `--auth jwt`; same as `make:middleware basic` / `make:middleware jwt`)
+- `src/middleware/basic.ts` or `src/middleware/jwt.ts` - Auth middleware (only when `--auth basic` or `--auth jwt`; same as `middleware:make basic` / `middleware:make jwt`)
 
 **Generated Project Structure (with `--auth jwt`):**
 ```
@@ -68,14 +68,14 @@ my-app/
 └── src/
     ├── index.ts
     ├── middleware/
-    │   └── jwt.ts    # Same as bunary make:middleware jwt
+    │   └── jwt.ts    # Same as bunary middleware:make jwt
     └── routes/
         ├── index.ts
         ├── main.ts
         └── groupExample.ts
 ```
 
-`init --auth basic` or `init --auth jwt` is a shortcut: it creates the same `src/middleware/basic.ts` or `src/middleware/jwt.ts` as running `bunary make:middleware basic` or `bunary make:middleware jwt` after init.
+`init --auth basic` or `init --auth jwt` is a shortcut: it creates the same `src/middleware/basic.ts` or `src/middleware/jwt.ts` as running `bunary middleware:make basic` or `bunary middleware:make jwt` after init.
 
 **Next Steps:**
 ```bash
@@ -110,18 +110,18 @@ src/models/
 └── Users.ts  # Generated from "users" table name
 ```
 
-### `bunary make:middleware <name>`
+### `bunary middleware:make <name>`
 
 Generate a middleware file in `src/middleware/` (Laravel-inspired).
 
 ```bash
 # Generate a generic middleware
-bunary make:middleware ensure-auth   # Creates src/middleware/ensure-auth.ts with ensureAuthMiddleware
-bunary make:middleware log-request   # Creates src/middleware/log-request.ts with logRequestMiddleware
+bunary middleware:make ensure-auth   # Creates src/middleware/ensure-auth.ts with ensureAuthMiddleware
+bunary middleware:make log-request   # Creates src/middleware/log-request.ts with logRequestMiddleware
 
 # Auth middleware (same stubs as init --auth basic|jwt)
-bunary make:middleware basic         # Creates src/middleware/basic.ts with basicMiddleware (@bunary/auth Basic guard)
-bunary make:middleware jwt           # Creates src/middleware/jwt.ts with jwtMiddleware (@bunary/auth JWT guard)
+bunary middleware:make basic         # Creates src/middleware/basic.ts with basicMiddleware (@bunary/auth Basic guard)
+bunary middleware:make jwt           # Creates src/middleware/jwt.ts with jwtMiddleware (@bunary/auth JWT guard)
 
 # The command automatically:
 # - Creates the file in src/middleware/ directory
@@ -140,14 +140,14 @@ src/middleware/
 └── ensure-auth.ts  # Exports ensureAuthMiddleware (Middleware type from @bunary/http)
 ```
 
-### `bunary make:migration <name>`
+### `bunary migration:make <name>`
 
 Create a migration file in `./migrations/` (Laravel-inspired). Requires `@bunary/orm`.
 
 ```bash
 # Create a migration (Laravel-style naming)
-bunary make:migration create_users_table   # Creates ./migrations/<timestamp>_create_users_table.ts
-bunary make:migration add_slug_to_posts    # Suggested table name "posts" in stub
+bunary migration:make create_users_table   # Creates ./migrations/<timestamp>_create_users_table.ts
+bunary migration:make add_slug_to_posts    # Suggested table name "posts" in stub
 
 # The command automatically:
 # - Creates the file in ./migrations/ with timestamp prefix (YYYYMMDDHHmmss_name.ts)
@@ -286,7 +286,7 @@ export function registerMain(app: BunaryApp): void {
 }
 ```
 
-### make:migration output
+### migration:make output
 
 Example `./migrations/20260129120000_create_users_table.ts`:
 
@@ -306,7 +306,7 @@ export async function down(): Promise<void> {
 }
 ```
 
-### make:middleware output (generic)
+### middleware:make output (generic)
 
 Example `src/middleware/ensure-auth.ts`:
 
@@ -369,7 +369,7 @@ await makeModel("user_profile");  // src/models/UserProfile.ts
 
 **InitOptions:** `{ auth?: "basic" | "jwt"; umbrella?: boolean }` — pass to `init`, `generatePackageJson`, `generateConfig`, `generateEntrypoint`, and route generators (`generateRoutesMain`, `generateRoutesIndex`, `generateRoutesGroupExample`) to control auth scaffolding and umbrella package usage.
 
-**Note:** `makeModel` and `generateMiddlewareContent` require a Bunary project context when writing files. Commands `make:middleware`, `make:migration`, `route:make`, and `migrate` are available via the CLI only.
+**Note:** `makeModel` and `generateMiddlewareContent` require a Bunary project context when writing files. Commands `middleware:make`, `migration:make`, `route:make`, and `migrate` are available via the CLI only.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,14 +16,98 @@ bunx @bunary/cli --help
 
 ## Commands (high level)
 
-- `bunary init [name] [--auth basic|jwt] [--umbrella]` — Create a new Bunary project (optionally with Basic or JWT auth; `--umbrella` uses `bunary` package instead of `@bunary/*`)
-- `bunary model:make <table-name>` — Generate an ORM model file
-- `bunary make:middleware <name>` — Generate a middleware in src/middleware/ (Laravel-inspired)
-- `bunary make:migration <name>` — Create a migration in ./migrations/ (Laravel-inspired)
-- `bunary migrate`, `bunary migrate:rollback`, `bunary migrate:status` — Run migrations
-- `bunary route:make <name>` — Generate a route module in src/routes/
+| Command | Description |
+|--------|-------------|
+| `bunary init [name] [--auth basic\|jwt] [--umbrella]` | Create a new Bunary project |
+| `bunary model:make <table-name>` | Generate ORM model in `src/models/` |
+| `bunary middleware:make <name>` | Generate middleware in `src/middleware/` |
+| `bunary migration:make <name>` | Create migration in `./migrations/` |
+| `bunary migrate` | Run pending migrations |
+| `bunary migrate:rollback` | Rollback last migration batch |
+| `bunary migrate:status` | Show migration status |
+| `bunary route:make <name>` | Generate route module in `src/routes/` |
+| `bunary --help`, `bunary --version` | Help and version |
 
-See the README for the full command reference.
+### bunary init [name] [--auth basic|jwt] [--umbrella]
+
+Creates a new Bunary project. You can pass a directory name or `.` for the current directory. With `--auth basic` or `--auth jwt` you get auth middleware stubs (same as running `middleware:make basic` or `jwt` after init). With `--umbrella` the project depends on the single `bunary` package and imports from `bunary/http` and `bunary/core` instead of `@bunary/http` and `@bunary/core`.
+
+```bash
+bunary init my-app
+bunary init my-app --auth jwt
+bunary init my-app --umbrella
+bunary init .
+```
+
+The command creates `package.json`, `bunary.config.ts`, `src/index.ts`, and `src/routes/` (main, groupExample, index). If you used `--auth`, it also creates `src/middleware/basic.ts` or `jwt.ts` and wires it in the entrypoint. Next steps: `cd <name>`, `bun install`, `bun run dev`.
+
+### bunary model:make \<table-name\>
+
+Generates an ORM model file in `src/models/`. Table names are converted to PascalCase (e.g. `user_profile` → `UserProfile.ts`). You must be in a Bunary project (package.json with `@bunary/core`). The command will not overwrite an existing file.
+
+### bunary middleware:make \<name\>
+
+Generates a middleware file in `src/middleware/`. For names `basic` or `jwt` it uses the auth stubs (Basic or JWT guard); for other names it uses a generic `(ctx, next)` stub. Requires a Bunary project.
+
+### bunary migration:make \<name\>
+
+Creates a migration file in `./migrations/` with a timestamp prefix (e.g. `20260129120000_create_users_table.ts`). The stub derives a table name from the migration name (e.g. `create_users_table` → `"users"`). Requires `@bunary/orm` in the project.
+
+### bunary migrate, migrate:rollback, migrate:status
+
+Run pending migrations, rollback the last batch, or show status. The CLI runs your project’s migrator; on first use it creates `scripts/migrate.ts`. The project needs `src/config/orm.ts` that calls `setOrmConfig` so the migrator can connect.
+
+### bunary route:make \<name\>
+
+Generates a route module in `src/routes/` with a register function (e.g. `registerUsers(app)`). You then add that function to `src/routes/index.ts` and call it from `registerRoutes`. Requires a Bunary project.
+
+## Generated files (examples)
+
+What init and the generators produce. With `init --umbrella`, imports use `bunary/http` and `bunary/core`; otherwise `@bunary/http` and `@bunary/core`.
+
+**package.json (default):** dependencies include `@bunary/core` and `@bunary/http`. With `--umbrella` you instead get a single `bunary` dependency; if you also pass `--auth basic` or `--auth jwt`, `@bunary/auth` is added to that (so `--umbrella --auth jwt` yields both `bunary` and `@bunary/auth`).
+
+**bunary.config.ts:** Uses `defineConfig` from `@bunary/core` (or `bunary/core` when umbrella). Sets app name, env, debug.
+
+**src/index.ts:** Creates the app with `createApp`, calls `registerRoutes(app)`, then `app.listen({ port: 3000 })`. With auth, it also imports the middleware and calls `app.use(basicMiddleware)` or `app.use(jwtMiddleware)`.
+
+**src/routes/main.ts:** Registers `/` and `/health`. groupExample registers `/api` and `/api/health`. You add `route:make` modules in `src/routes/index.ts`.
+
+**migration:make output:** A file with `up()` and `down()` using `Schema` from `@bunary/orm` (createTable/dropTable).
+
+**middleware:make output (generic):** A single export, e.g. `ensureAuthMiddleware`, of type `Middleware` from `@bunary/http`, with `(ctx, next)` and `return next()`.
+
+**route:make output:** A file that exports e.g. `registerUsers(app: BunaryApp)`; you wire it in `src/routes/index.ts`.
+
+## Programmatic API
+
+You can call init and the project generators from code. All of them are async.
+
+```typescript
+import {
+  init,
+  generatePackageJson,
+  generateConfig,
+  generateEntrypoint,
+  generateRoutesMain,
+  generateRoutesIndex,
+  generateRoutesGroupExample,
+  generateMiddlewareContent,
+  makeModel,
+} from "@bunary/cli";
+import type { InitOptions } from "@bunary/cli";
+
+await init("my-app");
+await init("my-app", { auth: "jwt", umbrella: true });
+
+const packageJson = await generatePackageJson("my-app", { umbrella: true });
+const config = await generateConfig("my-app", { umbrella: true });
+const entrypoint = await generateEntrypoint({ auth: "basic" });
+
+await makeModel("user_profile");  // run from a Bunary project directory
+```
+
+InitOptions: `{ auth?: "basic" | "jwt"; umbrella?: boolean }`. Pass to `init`, `generatePackageJson`, `generateConfig`, `generateEntrypoint`, and the route generators when you want auth scaffolding or umbrella imports. Commands like `middleware:make`, `migration:make`, `route:make`, and `migrate` are CLI-only; there is no programmatic API for those.
 
 ## Requirements
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -60,7 +60,7 @@ export async function init(name: string, options?: InitOptions): Promise<void> {
 		join(projectDir, "src", "index.ts"),
 		await generateEntrypoint(options),
 	);
-	// init --auth basic|jwt is a shortcut to make:middleware basic|jwt (same content, no double-up)
+	// init --auth basic|jwt is a shortcut to middleware:make basic|jwt (same content, no double-up)
 	if (options?.auth === "basic" || options?.auth === "jwt") {
 		await writeFile(
 			join(projectDir, "src", "middleware", `${options.auth}.ts`),

--- a/src/commands/middleware/makeMiddleware.ts
+++ b/src/commands/middleware/makeMiddleware.ts
@@ -1,5 +1,5 @@
 /**
- * make:middleware command - scaffold middleware files (Laravel-inspired)
+ * middleware:make command - scaffold middleware files (Laravel-inspired)
  * init --auth basic|jwt is a shortcut that uses this same content generator.
  */
 import { existsSync } from "node:fs";
@@ -10,7 +10,7 @@ import { loadStub } from "../../utils/stub.js";
 import { isBunaryProject } from "../../utils/validation.js";
 
 /**
- * Generate middleware file content. Used by make:middleware and by init --auth.
+ * Generate middleware file content. Used by middleware:make and by init --auth.
  * For "basic" and "jwt" uses auth stubs; for other names uses the generic middleware stub.
  *
  * @param middlewareName - e.g. "basic", "jwt", "ensure-auth", "log-request"
@@ -36,7 +36,7 @@ export async function generateMiddlewareContent(
 
 /**
  * Generate a middleware file in src/middleware/.
- * init --auth basic|jwt is equivalent to running make:middleware basic|jwt after init.
+ * init --auth basic|jwt is equivalent to running middleware:make basic|jwt after init.
  *
  * @param middlewareName - Middleware name (e.g. "basic", "jwt", "ensure-auth")
  * @throws Error if not in a Bunary project or file already exists

--- a/src/commands/migration/makeMigration.ts
+++ b/src/commands/migration/makeMigration.ts
@@ -1,5 +1,5 @@
 /**
- * make:migration command - create a new migration file (Laravel-inspired)
+ * migration:make command - create a new migration file (Laravel-inspired)
  */
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";

--- a/src/commands/project/entrypoint.ts
+++ b/src/commands/project/entrypoint.ts
@@ -7,7 +7,7 @@ import type { InitOptions } from "./types.js";
 
 /**
  * Generate entrypoint content, optionally with auth middleware.
- * init --auth basic|jwt uses the same middleware as make:middleware basic|jwt (basic.ts / jwt.ts).
+ * init --auth basic|jwt uses the same middleware as middleware:make basic|jwt (basic.ts / jwt.ts).
  *
  * @param options - When auth is "basic" or "jwt", adds import and app.use(basicMiddleware|jwtMiddleware)
  * @returns Entrypoint TypeScript content

--- a/src/help.ts
+++ b/src/help.ts
@@ -30,14 +30,14 @@ const commands: Command[] = [
 		usage: "bunary model:make <table-name>",
 	},
 	{
-		name: "make:middleware <name>",
+		name: "middleware:make <name>",
 		description: "Generate a middleware in src/middleware/ (Laravel-inspired)",
-		usage: "bunary make:middleware <name>",
+		usage: "bunary middleware:make <name>",
 	},
 	{
-		name: "make:migration <name>",
+		name: "migration:make <name>",
 		description: "Create a migration in ./migrations/ (Laravel-inspired)",
-		usage: "bunary make:migration <name>",
+		usage: "bunary migration:make <name>",
 	},
 	{
 		name: "migrate",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@
  *   bunary init <name> --auth basic|jwt - Scaffold with Basic or JWT auth
  *   bunary init .             - Create a new project in current directory
  *   bunary model:make <table>     - Generate an ORM model for <table>
- *   bunary make:middleware <name> - Generate a middleware in src/middleware/
- *   bunary make:migration <name>  - Create a migration in ./migrations/
+ *   bunary middleware:make <name> - Generate a middleware in src/middleware/
+ *   bunary migration:make <name>  - Create a migration in ./migrations/
  *   bunary migrate                - Run pending migrations
  *   bunary migrate:rollback      - Rollback last migration batch
  *   bunary migrate:status        - Show migration status
@@ -81,11 +81,11 @@ async function main(): Promise<void> {
 		return;
 	}
 
-	if (args[0] === "make:middleware") {
+	if (args[0] === "middleware:make") {
 		const middlewareName = args[1];
 		if (!middlewareName) {
 			console.error("Error: Middleware name is required");
-			console.error("Usage: bunary make:middleware <name>");
+			console.error("Usage: bunary middleware:make <name>");
 			process.exit(1);
 		}
 		try {
@@ -97,12 +97,12 @@ async function main(): Promise<void> {
 		return;
 	}
 
-	if (args[0] === "make:migration") {
+	if (args[0] === "migration:make") {
 		const migrationName = args[1];
 		if (!migrationName) {
 			console.error("Error: Migration name is required");
 			console.error(
-				"Usage: bunary make:migration <name>  (e.g. create_users_table)",
+				"Usage: bunary migration:make <name>  (e.g. create_users_table)",
 			);
 			process.exit(1);
 		}

--- a/src/utils/naming.ts
+++ b/src/utils/naming.ts
@@ -61,7 +61,7 @@ export function routeNameToRegisterFunctionName(routeName: string): string {
 
 /**
  * Convert a middleware name to its export function name (camelCase + "Middleware").
- * Laravel-inspired: make:middleware ensure-auth → ensureAuthMiddleware.
+ * Laravel-inspired: middleware:make ensure-auth → ensureAuthMiddleware.
  *
  * @param middlewareName - The middleware name (e.g. "ensure-auth", "log-request")
  * @returns The middleware function name (e.g. "ensureAuthMiddleware", "logRequestMiddleware")

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -100,7 +100,7 @@ describe("init command", () => {
 			);
 		});
 
-		test("with auth basic: adds @bunary/auth, src/middleware/basic.ts (same as make:middleware basic), and app.use(basicMiddleware)", async () => {
+		test("with auth basic: adds @bunary/auth, src/middleware/basic.ts (same as middleware:make basic), and app.use(basicMiddleware)", async () => {
 			const projectDir = join(TEST_DIR, "my-app");
 			process.chdir(TEST_DIR);
 			await init("my-app", { auth: "basic" });
@@ -128,7 +128,7 @@ describe("init command", () => {
 			expect(entryContent).toContain("./middleware/basic.js");
 		});
 
-		test("with auth jwt: adds @bunary/auth, src/middleware/jwt.ts (same as make:middleware jwt), and app.use(jwtMiddleware)", async () => {
+		test("with auth jwt: adds @bunary/auth, src/middleware/jwt.ts (same as middleware:make jwt), and app.use(jwtMiddleware)", async () => {
 			const projectDir = join(TEST_DIR, "my-app");
 			process.chdir(TEST_DIR);
 			await init("my-app", { auth: "jwt" });

--- a/tests/commands/make-middleware.test.ts
+++ b/tests/commands/make-middleware.test.ts
@@ -1,5 +1,5 @@
 /**
- * make:middleware command tests
+ * middleware:make command tests
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { makeMiddleware } from "../../src/commands/middleware/makeMiddleware.js";
 
-describe("make:middleware command", () => {
+describe("middleware:make command", () => {
 	let testDir: string;
 	let originalCwd: string;
 
@@ -125,7 +125,7 @@ describe("make:middleware command", () => {
 		expect(content).toContain("next");
 	});
 
-	it("make:middleware basic creates auth stub (same as init --auth basic)", async () => {
+	it("middleware:make basic creates auth stub (same as init --auth basic)", async () => {
 		await makeMiddleware("basic");
 
 		const content = readFileSync(
@@ -137,7 +137,7 @@ describe("make:middleware command", () => {
 		expect(content).toContain("createBasicGuard");
 	});
 
-	it("make:middleware jwt creates auth stub (same as init --auth jwt)", async () => {
+	it("middleware:make jwt creates auth stub (same as init --auth jwt)", async () => {
 		await makeMiddleware("jwt");
 
 		const content = readFileSync(

--- a/tests/commands/make-migration.test.ts
+++ b/tests/commands/make-migration.test.ts
@@ -1,5 +1,5 @@
 /**
- * make:migration command tests
+ * migration:make command tests
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { makeMigration } from "../../src/commands/migration/makeMigration.js";
 
-describe("make:migration command", () => {
+describe("migration:make command", () => {
 	let testDir: string;
 	let originalCwd: string;
 


### PR DESCRIPTION
Align command names with object:make pattern (like model:make, route:make).

- `make:migration` → `migration:make`
- `make:middleware` → `middleware:make`

CLI dispatch, help, README, docs/index.md, tests, CHANGELOG updated. No behavior change.

Closes #38