### PR TITLE
chore: remove --umbrella option from init (Closes #41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.13] - 2026-01-29
+
+### Removed
+
+- **`bunary init --umbrella`** (Closes #41) — Removed umbrella option. Init always uses `@bunary/core` and `@bunary/http`. The umbrella `bunary` package will live in its own repo.
+
 ## [0.0.12] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ bunx @bunary/cli init my-app
 
 | Command | Description |
 |--------|-------------|
-| `bunary init [name] [--auth basic\|jwt] [--umbrella]` | Create a new Bunary project |
+| `bunary init [name] [--auth basic\|jwt]` | Create a new Bunary project |
 | `bunary model:make <table>` | Generate ORM model in `src/models/` |
 | `bunary middleware:make <name>` | Generate middleware in `src/middleware/` |
 | `bunary migration:make <name>` | Create migration in `./migrations/` |
@@ -32,9 +32,9 @@ bunx @bunary/cli init my-app
 | `bunary route:make <name>` | Generate route module in `src/routes/` |
 | `bunary --help`, `bunary --version` | Help and version |
 
-### `bunary init [name] [--auth basic|jwt] [--umbrella]`
+### `bunary init [name] [--auth basic|jwt]`
 
-Create a new Bunary project, optionally with Basic or JWT auth scaffolding, or using the umbrella `bunary` package.
+Create a new Bunary project, optionally with Basic or JWT auth scaffolding.
 
 ```bash
 # Create a new project in a directory
@@ -46,15 +46,12 @@ bunary init my-app --auth basic
 # Scaffold with JWT (env: JWT_SECRET)
 bunary init my-app --auth jwt
 
-# Use umbrella package (bunary instead of @bunary/core + @bunary/http)
-bunary init my-app --umbrella
-
 # Create a project in the current directory
 bunary init .
 ```
 
 This creates a new Bunary project with:
-- `package.json` - Pre-configured with Bunary dependencies (`@bunary/core` + `@bunary/http` by default; single `bunary` when `--umbrella`; includes `@bunary/auth` when `--auth` is used)
+- `package.json` - Pre-configured with Bunary dependencies (`@bunary/core` + `@bunary/http`; includes `@bunary/auth` when `--auth` is used)
 - `bunary.config.ts` - Application configuration
 - `src/index.ts` - Entry point that registers routes via `src/routes/` (and `app.use(authMiddleware)` when `--auth` is used)
 - `src/routes/` - Route modules: `main.ts`, `groupExample.ts`, `index.ts`
@@ -209,7 +206,7 @@ bunary --version  # Show version
 
 ## Generated Files (examples)
 
-These examples match what the CLI generates. With `init --umbrella`, imports use `bunary/http` and `bunary/core` instead of `@bunary/http` and `@bunary/core`.
+These examples match what the CLI generates.
 
 ### package.json (default)
 
@@ -224,17 +221,17 @@ These examples match what the CLI generates. With `init --umbrella`, imports use
     "build": "bun build ./src/index.ts --outdir ./dist --target bun"
   },
   "dependencies": {
-    "@bunary/core": "^0.0.5",
-    "@bunary/http": "^0.0.4"
+    "@bunary/core": "^0.0.7",
+    "@bunary/http": "^0.0.11"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   }
 }
 ```
 
-With `--umbrella`, `dependencies` is `{ "bunary": "^0.0.1" }` instead of `@bunary/core` and `@bunary/http`. With `--auth basic` or `--auth jwt`, `@bunary/auth` is added.
+With `--auth basic` or `--auth jwt`, `@bunary/auth` is added.
 
 ### bunary.config.ts
 
@@ -249,8 +246,6 @@ export default defineConfig({
   },
 });
 ```
-
-With `init --umbrella`, the import is `from "bunary/core"`.
 
 ### src/index.ts
 
@@ -267,7 +262,7 @@ const server = app.listen({ port: 3000 });
 console.log(`🚀 Server running at http://localhost:${server.port}`);
 ```
 
-With `init --umbrella`, the import is `from "bunary/http"`. With `--auth basic` or `--auth jwt`, the file also imports the middleware and calls `app.use(basicMiddleware)` or `app.use(jwtMiddleware)`.
+With `--auth basic` or `--auth jwt`, the file also imports the middleware and calls `app.use(basicMiddleware)` or `app.use(jwtMiddleware)`.
 
 ### src/routes/
 
@@ -358,16 +353,15 @@ await init("my-app", { umbrella: true });
 
 // Generate individual files (e.g. for custom tooling)
 const packageJson = await generatePackageJson("my-app");
-const packageJsonUmbrella = await generatePackageJson("my-app", { umbrella: true });
-const config = await generateConfig("my-app", { umbrella: true });
+const config = await generateConfig("my-app");
 const entrypoint = await generateEntrypoint({ auth: "basic" });
-const routesMain = await generateRoutesMain({ umbrella: true });
+const routesMain = await generateRoutesMain();
 
 // Model generator (must be run from a Bunary project directory)
 await makeModel("user_profile");  // src/models/UserProfile.ts
 ```
 
-**InitOptions:** `{ auth?: "basic" | "jwt"; umbrella?: boolean }` — pass to `init`, `generatePackageJson`, `generateConfig`, `generateEntrypoint`, and route generators (`generateRoutesMain`, `generateRoutesIndex`, `generateRoutesGroupExample`) to control auth scaffolding and umbrella package usage.
+**InitOptions:** `{ auth?: "basic" | "jwt" }` — pass to `init`, `generatePackageJson`, `generateConfig`, `generateEntrypoint`, and route generators (`generateRoutesMain`, `generateRoutesIndex`, `generateRoutesGroupExample`) to control auth scaffolding.
 
 **Note:** `makeModel` and `generateMiddlewareContent` require a Bunary project context when writing files. Commands `middleware:make`, `migration:make`, `route:make`, and `migrate` are available via the CLI only.
 

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
 	"files": {
-		"includes": ["**", "!**/stubs/**"]
+		"includes": ["**", "!**/stubs"]
 	},
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ bunx @bunary/cli --help
 
 | Command | Description |
 |--------|-------------|
-| `bunary init [name] [--auth basic\|jwt] [--umbrella]` | Create a new Bunary project |
+| `bunary init [name] [--auth basic\|jwt]` | Create a new Bunary project |
 | `bunary model:make <table-name>` | Generate ORM model in `src/models/` |
 | `bunary middleware:make <name>` | Generate middleware in `src/middleware/` |
 | `bunary migration:make <name>` | Create migration in `./migrations/` |
@@ -28,14 +28,13 @@ bunx @bunary/cli --help
 | `bunary route:make <name>` | Generate route module in `src/routes/` |
 | `bunary --help`, `bunary --version` | Help and version |
 
-### bunary init [name] [--auth basic|jwt] [--umbrella]
+### bunary init [name] [--auth basic|jwt]
 
-Creates a new Bunary project. You can pass a directory name or `.` for the current directory. With `--auth basic` or `--auth jwt` you get auth middleware stubs (same as running `middleware:make basic` or `jwt` after init). With `--umbrella` the project depends on the single `bunary` package and imports from `bunary/http` and `bunary/core` instead of `@bunary/http` and `@bunary/core`.
+Creates a new Bunary project. You can pass a directory name or `.` for the current directory. With `--auth basic` or `--auth jwt` you get auth middleware stubs (same as running `middleware:make basic` or `jwt` after init).
 
 ```bash
 bunary init my-app
 bunary init my-app --auth jwt
-bunary init my-app --umbrella
 bunary init .
 ```
 
@@ -63,11 +62,11 @@ Generates a route module in `src/routes/` with a register function (e.g. `regist
 
 ## Generated files (examples)
 
-What init and the generators produce. With `init --umbrella`, imports use `bunary/http` and `bunary/core`; otherwise `@bunary/http` and `@bunary/core`.
+What init and the generators produce.
 
-**package.json (default):** dependencies include `@bunary/core` and `@bunary/http`. With `--umbrella` you instead get a single `bunary` dependency; if you also pass `--auth basic` or `--auth jwt`, `@bunary/auth` is added to that (so `--umbrella --auth jwt` yields both `bunary` and `@bunary/auth`).
+**package.json (default):** dependencies include `@bunary/core` and `@bunary/http`. With `--auth basic` or `--auth jwt`, `@bunary/auth` is added.
 
-**bunary.config.ts:** Uses `defineConfig` from `@bunary/core` (or `bunary/core` when umbrella). Sets app name, env, debug.
+**bunary.config.ts:** Uses `defineConfig` from `@bunary/core`. Sets app name, env, debug.
 
 **src/index.ts:** Creates the app with `createApp`, calls `registerRoutes(app)`, then `app.listen({ port: 3000 })`. With auth, it also imports the middleware and calls `app.use(basicMiddleware)` or `app.use(jwtMiddleware)`.
 
@@ -98,16 +97,16 @@ import {
 import type { InitOptions } from "@bunary/cli";
 
 await init("my-app");
-await init("my-app", { auth: "jwt", umbrella: true });
+await init("my-app", { auth: "jwt" });
 
-const packageJson = await generatePackageJson("my-app", { umbrella: true });
-const config = await generateConfig("my-app", { umbrella: true });
+const packageJson = await generatePackageJson("my-app");
+const config = await generateConfig("my-app");
 const entrypoint = await generateEntrypoint({ auth: "basic" });
 
 await makeModel("user_profile");  // run from a Bunary project directory
 ```
 
-InitOptions: `{ auth?: "basic" | "jwt"; umbrella?: boolean }`. Pass to `init`, `generatePackageJson`, `generateConfig`, `generateEntrypoint`, and the route generators when you want auth scaffolding or umbrella imports. Commands like `middleware:make`, `migration:make`, `route:make`, and `migrate` are CLI-only; there is no programmatic API for those.
+InitOptions: `{ auth?: "basic" | "jwt" }`. Pass to `init`, `generatePackageJson`, `generateConfig`, `generateEntrypoint`, and the route generators when you want auth scaffolding. Commands like `middleware:make`, `migration:make`, `route:make`, and `migrate` are CLI-only; there is no programmatic API for those.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "CLI scaffolding tool for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -20,12 +20,11 @@ export type { InitOptions } from "./project/types.js";
  * Initialize a new Bunary project.
  *
  * @param name - Project name or "." for current directory
- * @param options - Optional: auth "basic" or "jwt" to scaffold auth middleware; umbrella true to use bunary package instead of @bunary/*
+ * @param options - Optional: auth "basic" or "jwt" to scaffold auth middleware
  * @example
  * ```ts
  * await init("my-api");
  * await init("my-api", { auth: "jwt" });
- * await init("my-api", { umbrella: true });
  * ```
  */
 export async function init(name: string, options?: InitOptions): Promise<void> {

--- a/src/commands/project/config.ts
+++ b/src/commands/project/config.ts
@@ -4,13 +4,12 @@
 import { loadStub } from "../../utils/stub.js";
 import type { InitOptions } from "./types.js";
 
-const BUNARY_CORE = "@bunary/core";
-const BUNARY_CORE_UMBRELLA = "bunary/core";
-
 export async function generateConfig(
 	name: string,
-	options?: InitOptions,
+	_options?: InitOptions,
 ): Promise<string> {
-	const bunaryCore = options?.umbrella ? BUNARY_CORE_UMBRELLA : BUNARY_CORE;
-	return await loadStub("project/config.ts", { name, bunaryCore });
+	return await loadStub("project/config.ts", {
+		name,
+		bunaryCore: "@bunary/core",
+	});
 }

--- a/src/commands/project/entrypoint.ts
+++ b/src/commands/project/entrypoint.ts
@@ -12,9 +12,6 @@ import type { InitOptions } from "./types.js";
  * @param options - When auth is "basic" or "jwt", adds import and app.use(basicMiddleware|jwtMiddleware)
  * @returns Entrypoint TypeScript content
  */
-const BUNARY_HTTP = "@bunary/http";
-const BUNARY_HTTP_UMBRELLA = "bunary/http";
-
 export async function generateEntrypoint(
 	options?: InitOptions,
 ): Promise<string> {
@@ -25,10 +22,9 @@ export async function generateEntrypoint(
 		authImport = `import { ${exportName} } from "./middleware/${options.auth}.js";\n\n`;
 		authUse = `app.use(${exportName});\n`;
 	}
-	const bunaryHttp = options?.umbrella ? BUNARY_HTTP_UMBRELLA : BUNARY_HTTP;
 	return await loadStub("project/entrypoint.ts", {
 		authImport,
 		authUse,
-		bunaryHttp,
+		bunaryHttp: "@bunary/http",
 	});
 }

--- a/src/commands/project/packageJson.ts
+++ b/src/commands/project/packageJson.ts
@@ -7,14 +7,11 @@ import type { InitOptions } from "./types.js";
 /** @bunary/auth version for init --auth. Update when publishing a new auth release. */
 const BUNARY_AUTH_VERSION = "^0.0.7";
 
-/** Umbrella package version for init --umbrella. Sync with umbrella package release. */
-const BUNARY_UMBRELLA_VERSION = "^0.0.1";
-
 /**
  * Generate package.json content.
  *
  * @param name - Project name
- * @param options - Optional init options (auth, umbrella) to set dependencies
+ * @param options - Optional init options (auth) to set dependencies
  * @returns JSON string
  */
 export async function generatePackageJson(
@@ -25,9 +22,6 @@ export async function generatePackageJson(
 	const parsed = JSON.parse(content) as Record<string, unknown> & {
 		dependencies?: Record<string, string>;
 	};
-	if (options?.umbrella) {
-		parsed.dependencies = { bunary: BUNARY_UMBRELLA_VERSION };
-	}
 	if (options?.auth === "basic" || options?.auth === "jwt") {
 		parsed.dependencies = parsed.dependencies ?? {};
 		parsed.dependencies["@bunary/auth"] = BUNARY_AUTH_VERSION;

--- a/src/commands/project/routes.ts
+++ b/src/commands/project/routes.ts
@@ -4,34 +4,26 @@
 import { loadStub } from "../../utils/stub.js";
 import type { InitOptions } from "./types.js";
 
-function bunaryHttpReplacement(options?: InitOptions): Record<string, string> {
-	const bunaryHttp = options?.umbrella ? "bunary/http" : "@bunary/http";
-	return { bunaryHttp };
-}
+const BUNARY_HTTP = "@bunary/http";
 
 export async function generateRoutesMain(
-	options?: InitOptions,
+	_options?: InitOptions,
 ): Promise<string> {
-	return await loadStub(
-		"project/routes/main.ts",
-		bunaryHttpReplacement(options),
-	);
+	return await loadStub("project/routes/main.ts", { bunaryHttp: BUNARY_HTTP });
 }
 
 export async function generateRoutesGroupExample(
-	options?: InitOptions,
+	_options?: InitOptions,
 ): Promise<string> {
-	return await loadStub(
-		"project/routes/groupExample.ts",
-		bunaryHttpReplacement(options),
-	);
+	return await loadStub("project/routes/groupExample.ts", {
+		bunaryHttp: BUNARY_HTTP,
+	});
 }
 
 export async function generateRoutesIndex(
-	options?: InitOptions,
+	_options?: InitOptions,
 ): Promise<string> {
-	return await loadStub(
-		"project/routes/index.ts",
-		bunaryHttpReplacement(options),
-	);
+	return await loadStub("project/routes/index.ts", {
+		bunaryHttp: BUNARY_HTTP,
+	});
 }

--- a/src/commands/project/types.ts
+++ b/src/commands/project/types.ts
@@ -2,9 +2,7 @@
  * Shared types for init command and project generators.
  */
 
-/** Options for `bunary init` (e.g. auth scaffolding, umbrella package). */
+/** Options for `bunary init` (e.g. auth scaffolding). */
 export interface InitOptions {
 	auth?: "basic" | "jwt";
-	/** Use umbrella `bunary` package instead of individual @bunary/* deps. */
-	umbrella?: boolean;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -19,10 +19,10 @@ interface Option {
 
 const commands: Command[] = [
 	{
-		name: "init <name|.> [--auth basic|jwt] [--umbrella]",
+		name: "init <name|.> [--auth basic|jwt]",
 		description:
-			"Create a new Bunary project (optionally with Basic or JWT auth; --umbrella uses bunary package instead of @bunary/*)",
-		usage: "bunary init <name|.> [--auth basic|jwt] [--umbrella]",
+			"Create a new Bunary project (optionally with Basic or JWT auth)",
+		usage: "bunary init <name|.> [--auth basic|jwt]",
 	},
 	{
 		name: "model:make <table-name>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
 		if (!name) {
 			console.error("Error: Project name is required");
 			console.error(
-				"Usage: bunary init <name> [--auth basic|jwt] [--umbrella]  (or 'bunary init .' for current directory)",
+				"Usage: bunary init <name> [--auth basic|jwt]  (or 'bunary init .' for current directory)",
 			);
 			process.exit(1);
 		}
@@ -60,8 +60,7 @@ async function main(): Promise<void> {
 				auth = value;
 			}
 		}
-		const umbrella = args.includes("--umbrella");
-		await init(name, { auth, umbrella });
+		await init(name, { auth });
 		return;
 	}
 

--- a/stubs/project/packageJson.ts
+++ b/stubs/project/packageJson.ts
@@ -8,11 +8,11 @@
     "build": "bun build ./src/index.ts --outdir ./dist --target bun"
   },
   "dependencies": {
-    "@bunary/core": "^0.0.5",
-    "@bunary/http": "^0.0.4"
+    "@bunary/core": "^0.0.7",
+    "@bunary/http": "^0.0.11"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   }
 }

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -181,7 +181,7 @@ describe("init command", () => {
 			expect(entryContent).not.toContain("app.use(jwtMiddleware)");
 		});
 
-		test("without --umbrella: package.json has @bunary/core and @bunary/http, imports use @bunary/*", async () => {
+		test("package.json has @bunary/core and @bunary/http, imports use @bunary/*", async () => {
 			const projectDir = join(TEST_DIR, "my-app");
 			process.chdir(TEST_DIR);
 			await init("my-app");
@@ -191,7 +191,6 @@ describe("init command", () => {
 			);
 			expect(pkg.dependencies["@bunary/core"]).toBeDefined();
 			expect(pkg.dependencies["@bunary/http"]).toBeDefined();
-			expect(pkg.dependencies.bunary).toBeUndefined();
 
 			const entryContent = await Bun.file(
 				join(projectDir, "src", "index.ts"),
@@ -205,32 +204,6 @@ describe("init command", () => {
 				join(projectDir, "src", "routes", "main.ts"),
 			).text();
 			expect(mainContent).toContain('from "@bunary/http"');
-		});
-
-		test("with --umbrella: package.json has bunary, imports use bunary/http and bunary/core", async () => {
-			const projectDir = join(TEST_DIR, "my-app-umbrella");
-			process.chdir(TEST_DIR);
-			await init("my-app-umbrella", { umbrella: true });
-
-			const pkg = JSON.parse(
-				await Bun.file(join(projectDir, "package.json")).text(),
-			);
-			expect(pkg.dependencies.bunary).toBeDefined();
-			expect(pkg.dependencies["@bunary/core"]).toBeUndefined();
-			expect(pkg.dependencies["@bunary/http"]).toBeUndefined();
-
-			const entryContent = await Bun.file(
-				join(projectDir, "src", "index.ts"),
-			).text();
-			expect(entryContent).toContain('from "bunary/http"');
-			const configContent = await Bun.file(
-				join(projectDir, "bunary.config.ts"),
-			).text();
-			expect(configContent).toContain('from "bunary/core"');
-			const mainContent = await Bun.file(
-				join(projectDir, "src", "routes", "main.ts"),
-			).text();
-			expect(mainContent).toContain('from "bunary/http"');
 		});
 	});
 
@@ -270,16 +243,6 @@ describe("init command", () => {
 			expect(parsed.dependencies["@bunary/auth"]).toBeDefined();
 		});
 
-		test("with umbrella: includes bunary dependency, no @bunary/core or @bunary/http", async () => {
-			const json = await generatePackageJson("test-app", {
-				umbrella: true,
-			});
-			const parsed = JSON.parse(json);
-			expect(parsed.dependencies.bunary).toBeDefined();
-			expect(parsed.dependencies["@bunary/core"]).toBeUndefined();
-			expect(parsed.dependencies["@bunary/http"]).toBeUndefined();
-		});
-
 		test("includes dev script", async () => {
 			const json = await generatePackageJson("test-app");
 			const parsed = JSON.parse(json);
@@ -304,14 +267,9 @@ describe("init command", () => {
 			expect(config).toContain("development");
 		});
 
-		test("without umbrella uses @bunary/core", async () => {
+		test("uses @bunary/core", async () => {
 			const config = await generateConfig("test-app");
 			expect(config).toContain('from "@bunary/core"');
-		});
-
-		test("with umbrella uses bunary/core", async () => {
-			const config = await generateConfig("test-app", { umbrella: true });
-			expect(config).toContain('from "bunary/core"');
 		});
 	});
 
@@ -358,14 +316,9 @@ describe("init command", () => {
 			expect(entry).not.toContain("jwtMiddleware");
 		});
 
-		test("without umbrella uses @bunary/http", async () => {
+		test("uses @bunary/http", async () => {
 			const entry = await generateEntrypoint();
 			expect(entry).toContain('from "@bunary/http"');
-		});
-
-		test("with umbrella uses bunary/http", async () => {
-			const entry = await generateEntrypoint({ umbrella: true });
-			expect(entry).toContain('from "bunary/http"');
 		});
 	});
 });


### PR DESCRIPTION
Removes the `--umbrella` option and all related code. Init always uses `@bunary/core` and `@bunary/http`. The umbrella `bunary` package will live in its own repo.

**Changes:**
- `InitOptions`: removed `umbrella?: boolean`
- `packageJson.ts`: removed umbrella branch and `BUNARY_UMBRELLA_VERSION`
- `entrypoint.ts`, `config.ts`, `routes.ts`: always use `@bunary/http` and `@bunary/core`
- `init.ts`, `index.ts`, `help.ts`: removed `--umbrella` from usage and args
- Tests: removed umbrella-specific tests
- README, docs/index.md: removed umbrella references
- CHANGELOG: 0.0.13 entry; restored 0.0.12 entry
- Version bump to 0.0.13 (0.0.12 already published)