### PR TITLE
ci: add release tag workflow on merge to main

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,10 +18,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: oven-sh/setup-bun@v2
+
       - name: Get and validate version from package.json
         id: version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION=$(bun -p "require('./package.json').version")
           if [ -z "$VERSION" ]; then
             echo "::error::package.json version is empty"
             exit 1


### PR DESCRIPTION
Closes #46
Closes bunary-dev/.github#5

## Summary

Add GitHub workflow that creates a git tag when changes are merged to main. Based on validated workflow from bunary-dev/examples#28.

## Workflow behavior

- **Trigger:** Push to main
- **Version validation:** Semver format (x.y.z or x.y.z-prerelease)
- **Tag exists check:** Fails if tag already exists — enforces version bump discipline
- **No force push:** Normal tag push only
- **Concurrency:** One run at a time to avoid races on rapid merges