### PR TITLE
feat: discover and run project-level custom commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-02-20
+
+### Added
+
+- **Discover and run project-level custom commands** (Closes #63)
+  - Projects can define custom CLI commands in `bunary.config.ts` via a `commands` array
+  - Config file lookup: tries `config/bunary.ts` first, then `bunary.config.ts`
+  - Project commands merge into the registry alongside built-in commands
+  - `bunary --help` shows project commands in a dedicated "Project" section
+  - Name collision protection: project commands cannot override built-in commands
+  - Invalid command entries (missing name, description, or run) are silently skipped
+  - New `loadProjectCommands` utility in `src/utils/loadProjectCommands.ts`
+  - New `registerProjectCommands` and `resetRegistry` functions in `src/registry.ts`
+  - Added `"project"` to `CommandCategory` type
+  - 23 new tests across 3 test files (235 total tests passing)
+
 ## [0.1.5] - 2026-02-19
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,3 +112,64 @@ InitOptions: `{ auth?: "basic" | "jwt" }`. Pass to `init`, `generatePackageJson`
 
 - Bun ≥ 1.0.0
 
+## Custom Project Commands
+
+You can add your own CLI commands to any Bunary project. The CLI picks them up automatically when you run `bunary` from that project directory.
+
+### Where to put them
+
+Create a `src/commands/` directory and export one command per file:
+
+```
+my-app/
+  config/
+    bunary.ts          ← register commands here
+  src/
+    commands/
+      seed.ts          ← your custom command
+      deploy.ts
+    routes/
+    index.ts
+```
+
+### Defining a command
+
+Each command is a plain object with `name`, `description`, and an async `run` function:
+
+```typescript
+// src/commands/seed.ts
+export const seedDatabase = {
+  name: "db:seed",
+  description: "Seed the database with test data",
+  category: "project",
+  run: async () => {
+    console.log("Seeding...");
+    // your logic here
+  },
+};
+```
+
+### Registering commands in config
+
+Add a `commands` array to your config file. The CLI looks for `config/bunary.ts` first, then falls back to `bunary.config.ts`:
+
+```typescript
+// config/bunary.ts
+import { defineConfig } from "@bunary/core";
+import { seedDatabase } from "../src/commands/seed.js";
+import { deploy } from "../src/commands/deploy.js";
+
+export default defineConfig({
+  app: { name: "my-app" },
+  commands: [seedDatabase, deploy],
+});
+```
+
+Now `bunary db:seed` and `bunary deploy` work from your project root. They also show up under a "Project" section in `bunary --help`.
+
+### Rules
+
+- Project commands can't override built-in commands (`init`, `migrate`, etc.). The CLI throws if there's a name collision.
+- Commands missing `name`, `description`, or `run` are silently skipped.
+- If `category` is omitted it defaults to `"project"`.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bunary/cli",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "CLI scaffolding tool for Bunary - a Bun-first backend framework inspired by Laravel",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/src/help.ts
+++ b/src/help.ts
@@ -15,10 +15,11 @@ const CMD_COL = 26;
 const CATEGORY_LABELS: Record<CommandCategory, string> = {
 	scaffold: "Scaffold",
 	database: "Database",
+	project: "Project",
 };
 
 /** Ordered list of categories to display. */
-const CATEGORY_ORDER: CommandCategory[] = ["scaffold", "database"];
+const CATEGORY_ORDER: CommandCategory[] = ["scaffold", "database", "project"];
 
 /** Built-in global options shown in every help output. */
 const builtinOptions = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,17 +19,26 @@ const args = process.argv.slice(2);
 
 async function main(): Promise<void> {
 	// Load project-level commands when inside a Bunary project
+	let projectCommands: Awaited<ReturnType<typeof loadProjectCommands>> = [];
 	try {
-		const projectCommands = await loadProjectCommands();
-		if (projectCommands.length > 0) {
-			registerProjectCommands(projectCommands);
-		}
+		projectCommands = await loadProjectCommands();
 	} catch (error) {
 		console.error(
 			dim(
 				`Warning: Failed to load project commands — ${error instanceof Error ? error.message : String(error)}`,
 			),
 		);
+	}
+
+	if (projectCommands.length > 0) {
+		try {
+			registerProjectCommands(projectCommands);
+		} catch (error) {
+			console.error(
+				red(error instanceof Error ? error.message : String(error)),
+			);
+			process.exit(1);
+		}
 	}
 
 	if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,9 @@
  */
 
 import { showHelp } from "./help.js";
-import { findCommand } from "./registry.js";
+import { findCommand, registerProjectCommands } from "./registry.js";
 import { dim, red } from "./utils/color.js";
+import { loadProjectCommands } from "./utils/loadProjectCommands.js";
 import { parseFlags, validateFlags } from "./utils/parseFlags.js";
 import { suggestCommand } from "./utils/suggest.js";
 import { getVersion } from "./utils/version.js";
@@ -17,6 +18,20 @@ import { getVersion } from "./utils/version.js";
 const args = process.argv.slice(2);
 
 async function main(): Promise<void> {
+	// Load project-level commands when inside a Bunary project
+	try {
+		const projectCommands = await loadProjectCommands();
+		if (projectCommands.length > 0) {
+			registerProjectCommands(projectCommands);
+		}
+	} catch (error) {
+		console.error(
+			dim(
+				`Warning: Failed to load project commands — ${error instanceof Error ? error.message : String(error)}`,
+			),
+		);
+	}
+
 	if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
 		showHelp();
 		return;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -3,6 +3,8 @@
  *
  * Collects command definitions from each command module and provides
  * lookup helpers used by the dispatcher, help output, and suggestions.
+ * Project-level commands can be merged in at runtime via
+ * {@link registerProjectCommands}.
  *
  * @example
  * ```ts
@@ -25,8 +27,8 @@ import { command as modelMakeCommand } from "./commands/model/makeModel.js";
 import { command as routeMakeCommand } from "./commands/route/makeRoute.js";
 import type { Command } from "./types/command.js";
 
-/** All registered CLI commands. */
-export const commands: readonly Command[] = [
+/** Built-in commands that ship with the CLI. */
+const builtinCommands: readonly Command[] = [
 	initCommand,
 	routeMakeCommand,
 	middlewareMakeCommand,
@@ -36,6 +38,64 @@ export const commands: readonly Command[] = [
 	migrateRollbackCommand,
 	migrateStatusCommand,
 ];
+
+/** All registered CLI commands (built-in + project). */
+export let commands: readonly Command[] = [...builtinCommands];
+
+/**
+ * Register project-level commands into the registry.
+ *
+ * Validates that no project command name collides with a built-in
+ * command or another project command in the same batch.
+ *
+ * @param projectCommands - Array of project command definitions
+ * @throws When a project command name collides with a built-in command
+ * @throws When duplicate names exist in the project commands
+ *
+ * @example
+ * ```ts
+ * registerProjectCommands([
+ *   { name: "db:seed", description: "Seed DB", category: "project", run: async () => {} },
+ * ]);
+ * ```
+ */
+export function registerProjectCommands(projectCommands: Command[]): void {
+	if (projectCommands.length === 0) return;
+
+	const builtinNames = new Set(builtinCommands.map((c) => c.name));
+	const seen = new Set<string>();
+
+	for (const cmd of projectCommands) {
+		if (builtinNames.has(cmd.name)) {
+			throw new Error(
+				`Cannot override built-in command "${cmd.name}". Choose a different name for your project command.`,
+			);
+		}
+		if (seen.has(cmd.name)) {
+			throw new Error(
+				`Duplicate command name "${cmd.name}" in project commands. Each command must have a unique name.`,
+			);
+		}
+		seen.add(cmd.name);
+	}
+
+	commands = [...commands, ...projectCommands];
+}
+
+/**
+ * Reset the registry to only built-in commands.
+ *
+ * Removes any project commands that were registered via
+ * {@link registerProjectCommands}. Useful for testing.
+ *
+ * @example
+ * ```ts
+ * resetRegistry(); // back to built-in commands only
+ * ```
+ */
+export function resetRegistry(): void {
+	commands = [...builtinCommands];
+}
 
 /**
  * Find a command by exact name.

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -63,7 +63,7 @@ export interface CommandFlag {
 }
 
 /** Help category for grouped output. */
-export type CommandCategory = "scaffold" | "database";
+export type CommandCategory = "scaffold" | "database" | "project";
 
 /**
  * A CLI command definition.

--- a/src/utils/loadProjectCommands.ts
+++ b/src/utils/loadProjectCommands.ts
@@ -1,0 +1,118 @@
+/**
+ * Load project-level commands from the user's Bunary config file.
+ *
+ * Searches for a config file at `config/bunary.ts` (preferred) or
+ * `bunary.config.ts` (fallback), dynamically imports it, and extracts
+ * the `commands` array. Each entry is validated for required fields
+ * (`name`, `description`, `run`) and defaults `category` to `"project"`.
+ *
+ * Returns an empty array when:
+ * - The directory is not a Bunary project
+ * - No config file exists
+ * - The config has no `commands` key
+ * - The config file fails to load
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { Command } from "../types/command.js";
+import { isBunaryProject } from "./validation.js";
+
+/** Config file paths to try, in priority order. */
+const CONFIG_PATHS = ["config/bunary.ts", "bunary.config.ts"] as const;
+
+/**
+ * Check whether a value looks like a valid `Command` definition.
+ *
+ * A command must have at minimum a string `name`, string `description`,
+ * and a `run` function.
+ *
+ * @param entry - The value to validate
+ * @returns `true` if the entry has the required command shape
+ *
+ * @example
+ * ```ts
+ * isValidCommand({ name: "seed", description: "Seed DB", run: async () => {} }); // true
+ * isValidCommand({ description: "No name" }); // false
+ * ```
+ */
+function isValidCommand(entry: unknown): entry is Command {
+	if (typeof entry !== "object" || entry === null) return false;
+	const obj = entry as Record<string, unknown>;
+	return (
+		typeof obj.name === "string" &&
+		obj.name.length > 0 &&
+		typeof obj.description === "string" &&
+		typeof obj.run === "function"
+	);
+}
+
+/**
+ * Resolve the config file path inside a project directory.
+ *
+ * Tries `config/bunary.ts` first, then `bunary.config.ts`.
+ *
+ * @param cwd - Project root directory
+ * @returns Absolute path to the config file, or `undefined` if none exists
+ *
+ * @example
+ * ```ts
+ * const path = resolveConfigPath("/my/project");
+ * // "/my/project/config/bunary.ts" or undefined
+ * ```
+ */
+function resolveConfigPath(cwd: string): string | undefined {
+	for (const relative of CONFIG_PATHS) {
+		const absolute = join(cwd, relative);
+		if (existsSync(absolute)) return absolute;
+	}
+	return undefined;
+}
+
+/**
+ * Load project-level commands from the Bunary config file.
+ *
+ * Dynamically imports the user's config, extracts the `commands` array,
+ * validates each entry, and defaults `category` to `"project"`.
+ *
+ * @param cwd - Project root directory (defaults to `process.cwd()`)
+ * @returns Array of validated project commands, or empty array on failure
+ *
+ * @example
+ * ```ts
+ * const cmds = await loadProjectCommands("/path/to/project");
+ * for (const cmd of cmds) {
+ *   console.log(cmd.name); // "db:seed", "deploy", etc.
+ * }
+ * ```
+ */
+export async function loadProjectCommands(
+	cwd: string = process.cwd(),
+): Promise<Command[]> {
+	if (!isBunaryProject(cwd)) return [];
+
+	const configPath = resolveConfigPath(cwd);
+	if (!configPath) return [];
+
+	let config: Record<string, unknown>;
+	try {
+		const mod = await import(configPath);
+		config = mod.default ?? mod;
+	} catch {
+		return [];
+	}
+
+	const raw = config.commands;
+	if (!Array.isArray(raw) || raw.length === 0) return [];
+
+	const validated: Command[] = [];
+	for (const entry of raw) {
+		if (!isValidCommand(entry)) continue;
+		validated.push({
+			...entry,
+			category: entry.category ?? "project",
+		});
+	}
+
+	return validated;
+}

--- a/tests/commands/help-project-commands.test.ts
+++ b/tests/commands/help-project-commands.test.ts
@@ -8,22 +8,18 @@ import type { Command } from "../../src/types/command.js";
 
 describe("help with project commands", () => {
 	let output: string;
+	const origLog = console.log;
 
 	beforeEach(() => {
 		resetRegistry();
 		output = "";
-		// Capture console.log output
-		const origLog = console.log;
 		console.log = (msg: string) => {
 			output += msg;
 		};
-		// Restore after capture
-		afterEach(() => {
-			console.log = origLog;
-		});
 	});
 
 	afterEach(() => {
+		console.log = origLog;
 		resetRegistry();
 	});
 

--- a/tests/commands/help-project-commands.test.ts
+++ b/tests/commands/help-project-commands.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for project commands appearing in CLI help output.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { showHelp } from "../../src/help.js";
+import { registerProjectCommands, resetRegistry } from "../../src/registry.js";
+import type { Command } from "../../src/types/command.js";
+
+describe("help with project commands", () => {
+	let output: string;
+
+	beforeEach(() => {
+		resetRegistry();
+		output = "";
+		// Capture console.log output
+		const origLog = console.log;
+		console.log = (msg: string) => {
+			output += msg;
+		};
+		// Restore after capture
+		afterEach(() => {
+			console.log = origLog;
+		});
+	});
+
+	afterEach(() => {
+		resetRegistry();
+	});
+
+	test("project commands appear under Project section", () => {
+		const cmd: Command = {
+			name: "db:seed",
+			description: "Seed the database",
+			category: "project",
+			run: async () => {},
+		};
+		registerProjectCommands([cmd]);
+		showHelp();
+
+		expect(output).toContain("Project");
+		expect(output).toContain("db:seed");
+		expect(output).toContain("Seed the database");
+	});
+
+	test("Project section does not appear when no project commands", () => {
+		showHelp();
+		expect(output).not.toContain("Project");
+	});
+
+	test("project commands are separated from built-in commands", () => {
+		const cmd: Command = {
+			name: "deploy",
+			description: "Deploy the app",
+			category: "project",
+			run: async () => {},
+		};
+		registerProjectCommands([cmd]);
+		showHelp();
+
+		// Built-in sections still present
+		expect(output).toContain("Scaffold");
+		expect(output).toContain("Database");
+		// Project section present
+		expect(output).toContain("Project");
+	});
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -33,7 +33,11 @@ describe("command registry", () => {
 	});
 
 	test("every command has a valid category", () => {
-		const validCategories: CommandCategory[] = ["scaffold", "database"];
+		const validCategories: CommandCategory[] = [
+			"scaffold",
+			"database",
+			"project",
+		];
 		for (const cmd of commands) {
 			expect(validCategories).toContain(cmd.category);
 		}

--- a/tests/utils/load-project-commands.test.ts
+++ b/tests/utils/load-project-commands.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for project command loading from user config files.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadProjectCommands } from "../../src/utils/loadProjectCommands.js";
+
+describe("loadProjectCommands", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = await mkdtemp(join(tmpdir(), "bunary-cli-test-"));
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	test("returns empty array when not a Bunary project", async () => {
+		const result = await loadProjectCommands(testDir);
+		expect(result).toEqual([]);
+	});
+
+	test("returns empty array when no config file exists", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toEqual([]);
+	});
+
+	test("loads commands from config/bunary.ts", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "db:seed",
+						description: "Seed the database",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("db:seed");
+		expect(result[0].description).toBe("Seed the database");
+		expect(result[0].category).toBe("project");
+	});
+
+	test("loads commands from bunary.config.ts as fallback", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await writeFile(
+			join(testDir, "bunary.config.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "deploy",
+						description: "Deploy the application",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("deploy");
+	});
+
+	test("prefers config/bunary.ts over bunary.config.ts", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "from-config-dir",
+						description: "From config dir",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		await writeFile(
+			join(testDir, "bunary.config.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "from-root",
+						description: "From root",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("from-config-dir");
+	});
+
+	test("returns empty array when config has no commands key", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default { app: { name: "test-app" } };`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toEqual([]);
+	});
+
+	test("returns empty array when commands is empty array", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default { app: { name: "test-app" }, commands: [] };`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toEqual([]);
+	});
+
+	test("loads multiple commands from config", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "db:seed",
+						description: "Seed the database",
+						category: "project",
+						run: async () => {},
+					},
+					{
+						name: "deploy",
+						description: "Deploy the application",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(2);
+		expect(result.map((c) => c.name)).toEqual(["db:seed", "deploy"]);
+	});
+
+	test("skips commands with missing name", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						description: "Missing name",
+						category: "project",
+						run: async () => {},
+					},
+					{
+						name: "valid-cmd",
+						description: "Valid command",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("valid-cmd");
+	});
+
+	test("skips commands with missing run function", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "no-run",
+						description: "Missing run",
+						category: "project",
+					},
+					{
+						name: "valid-cmd",
+						description: "Valid command",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("valid-cmd");
+	});
+
+	test("defaults category to 'project' when not specified", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "custom-cmd",
+						description: "Custom command",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(1);
+		expect(result[0].category).toBe("project");
+	});
+
+	test("returns empty array when config file has syntax error", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {{{ invalid syntax`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toEqual([]);
+	});
+});

--- a/tests/utils/load-project-commands.test.ts
+++ b/tests/utils/load-project-commands.test.ts
@@ -251,6 +251,41 @@ describe("loadProjectCommands", () => {
 		expect(result[0].name).toBe("valid-cmd");
 	});
 
+	test("skips commands with missing description", async () => {
+		await writeFile(
+			join(testDir, "package.json"),
+			JSON.stringify({
+				name: "test-app",
+				dependencies: { "@bunary/core": "^0.2.0" },
+			}),
+		);
+
+		await mkdir(join(testDir, "config"), { recursive: true });
+		await writeFile(
+			join(testDir, "config", "bunary.ts"),
+			`export default {
+				app: { name: "test-app" },
+				commands: [
+					{
+						name: "no-desc",
+						category: "project",
+						run: async () => {},
+					},
+					{
+						name: "valid-cmd",
+						description: "Valid command",
+						category: "project",
+						run: async () => {},
+					},
+				],
+			};`,
+		);
+
+		const result = await loadProjectCommands(testDir);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("valid-cmd");
+	});
+
 	test("skips commands with missing run function", async () => {
 		await writeFile(
 			join(testDir, "package.json"),

--- a/tests/utils/register-project-commands.test.ts
+++ b/tests/utils/register-project-commands.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for project command registration in the command registry.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+	commands,
+	findCommand,
+	getCommandNames,
+	registerProjectCommands,
+	resetRegistry,
+} from "../../src/registry.js";
+import type { Command } from "../../src/types/command.js";
+
+/** Factory for a minimal valid project command. */
+function makeProjectCommand(overrides: Partial<Command> = {}): Command {
+	return {
+		name: "test:cmd",
+		description: "A test project command",
+		category: "project",
+		run: async () => {},
+		...overrides,
+	};
+}
+
+describe("registerProjectCommands", () => {
+	beforeEach(() => {
+		resetRegistry();
+	});
+
+	test("merges project commands into the registry", () => {
+		const before = commands.length;
+		registerProjectCommands([makeProjectCommand({ name: "my:cmd" })]);
+		expect(commands.length).toBe(before + 1);
+	});
+
+	test("project commands are findable by name", () => {
+		registerProjectCommands([makeProjectCommand({ name: "deploy" })]);
+		const cmd = findCommand("deploy");
+		expect(cmd).toBeDefined();
+		expect(cmd?.name).toBe("deploy");
+	});
+
+	test("project command names appear in getCommandNames", () => {
+		registerProjectCommands([makeProjectCommand({ name: "db:seed" })]);
+		const names = getCommandNames();
+		expect(names).toContain("db:seed");
+	});
+
+	test("throws when project command name collides with built-in", () => {
+		expect(() => {
+			registerProjectCommands([makeProjectCommand({ name: "init" })]);
+		}).toThrow(/cannot override built-in command/i);
+	});
+
+	test("throws when project command name collides with another project command", () => {
+		expect(() => {
+			registerProjectCommands([
+				makeProjectCommand({ name: "dup" }),
+				makeProjectCommand({ name: "dup" }),
+			]);
+		}).toThrow(/duplicate.*command/i);
+	});
+
+	test("built-in commands remain intact after registration", () => {
+		registerProjectCommands([makeProjectCommand({ name: "custom" })]);
+
+		const builtInNames = [
+			"init",
+			"route:make",
+			"middleware:make",
+			"model:make",
+			"migration:make",
+			"migrate",
+			"migrate:rollback",
+			"migrate:status",
+		];
+		for (const name of builtInNames) {
+			expect(findCommand(name)).toBeDefined();
+		}
+	});
+
+	test("registering empty array is a no-op", () => {
+		const before = commands.length;
+		registerProjectCommands([]);
+		expect(commands.length).toBe(before);
+	});
+});
+
+describe("resetRegistry", () => {
+	test("removes project commands but keeps built-ins", () => {
+		registerProjectCommands([makeProjectCommand({ name: "temp:cmd" })]);
+		expect(findCommand("temp:cmd")).toBeDefined();
+
+		resetRegistry();
+		expect(findCommand("temp:cmd")).toBeUndefined();
+		expect(findCommand("init")).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary

Projects can now define custom CLI commands in their Bunary config file (`config/bunary.ts` or `bunary.config.ts`) via a `commands` array. The CLI discovers these at startup, validates them, and merges them into the registry alongside built-in commands — similar to how Laravel Artisan picks up custom commands.

Closes #63

## How it works

1. On startup, the CLI checks if it's inside a Bunary project (`isBunaryProject()`)
2. If yes, it looks for a config file: `config/bunary.ts` first, then `bunary.config.ts`
3. Dynamically imports the config and extracts the `commands` array
4. Validates each entry (must have `name`, `description`, and `run`)
5. Registers valid commands into the registry with `category: "project"` default
6. `bunary --help` shows project commands in a dedicated **Project** section

### User-facing example

```ts
// config/bunary.ts
import { defineConfig } from "@bunary/core";
import { seedDatabase } from "./src/commands/seed.js";

export default defineConfig({
  app: { name: "my-app", port: 3000 },
  commands: [seedDatabase],
});
```

```ts
// src/commands/seed.ts
export const seedDatabase = {
  name: "db:seed",
  description: "Seed the database with test data",
  category: "project",
  run: async () => { /* ... */ },
};
```

Running `bunary db:seed` executes the custom command. Running `bunary --help` shows it under "Project".

## Changes

- **`src/types/command.ts`** — Added `"project"` to `CommandCategory` union
- **`src/utils/loadProjectCommands.ts`** (new) — Config file discovery, dynamic import, validation
- **`src/registry.ts`** — `registerProjectCommands()` with collision detection, `resetRegistry()` for tests
- **`src/help.ts`** — Added "Project" category label and ordering
- **`src/index.ts`** — Loads project commands at startup before dispatch; loading errors warn, registration errors (name collisions) exit with error
- **`docs/index.md`** — Added "Custom Project Commands" section with placement and registration examples

## Error handling

Loading errors and registration errors are handled separately:
- **Config loading failures** (syntax errors, missing files) show a dim warning and the CLI continues normally
- **Registration errors** (name collision with built-in commands, duplicate names) print a red error and exit with code 1, since these indicate a config problem the user needs to fix

## Safety

- Project commands **cannot** override built-in commands (exits with error on collision)
- Duplicate project command names are rejected
- Invalid entries (missing name/description/run) are silently skipped
- Config import failures return empty array (non-blocking)

## Tests

24 new tests across 3 files (236 total passing):
- `tests/utils/load-project-commands.test.ts` — 13 tests for config loading (including missing name, description, and run validation)
- `tests/utils/register-project-commands.test.ts` — 8 tests for registry integration  
- `tests/commands/help-project-commands.test.ts` — 3 tests for help output